### PR TITLE
Fix bug with sending attached messages

### DIFF
--- a/faust/app.py
+++ b/faust/app.py
@@ -466,7 +466,7 @@ class App(AppT, ServiceProxy):
             # being committed
             if entry[0] <= commit_offset:
                 # we use it
-                yield entry
+                yield entry[1]  # Only yielding Pending Message (not offset)
             else:
                 # we put it back and exit, as this was the smallest offset.
                 heappush(attached, entry)


### PR DESCRIPTION
## Fix changelogging

There was in issue with sending attached messages upon committing which was causing us to send messages to topic = offset instead of the changelog topic. 

This is fixed here. Not sure if this is the best way to structure things though and if we need to type annotate things better here.

@ask @arpanshah29 