### PR TITLE
Consumer decouple

### DIFF
--- a/faust/app.py
+++ b/faust/app.py
@@ -106,7 +106,7 @@ class AppService(Service):
             self.app.tables.values(),
             # WebSite
             [self.app.website],                       # app.WebSite
-            # TopicManager stops consumer
+            # TopicManager
             [self.app.sources],                       # app.TopicManager
             # Actors last.
             self.app.actors.values(),

--- a/faust/topics.py
+++ b/faust/topics.py
@@ -346,9 +346,6 @@ class TopicManager(TopicManagerT, Service):
         # tell the consumer to subscribe to our pattern
         await self.app.consumer.subscribe(self._pattern)
 
-        # and start the consumer
-        await self.app.consumer.start()
-
         # Now we wait for changes
         cond = self._subscription_changed = asyncio.Condition(loop=self.loop)
         while 1:

--- a/faust/types/topics.py
+++ b/faust/types/topics.py
@@ -165,10 +165,6 @@ class TopicManagerT(ServiceT, MutableSet[SourceT]):
         ...
 
     @abc.abstractmethod
-    async def on_message(self, message: Message) -> None:
-        ...
-
-    @abc.abstractmethod
     def on_partitions_assigned(self,
                                assigned: Sequence[TopicPartition]) -> None:
         ...


### PR DESCRIPTION
## Decouple Consumer Service from TopicManger

Making the consumer a service within AppService instead of within the TopicManager service. This is so that the app has access to the consumer/client which can further be used by the different components of the app (table)

This would be useful as tables and streams need to be able to create topics (if required) which would involve access to the transport (producer/consumer).

Not sure if this is the way to go, but creating PR for review.

The consumer works as expected with the simple example. There are a few issues with the typecheck due to moving things around. Specifically I was not able to make ConsumerT an attribute of AppT as that would result in cyclic dependencies. 
