### PR TITLE
Wait for seek to be completed

### DIFF
--- a/faust/transport/aiokafka.py
+++ b/faust/transport/aiokafka.py
@@ -203,12 +203,14 @@ class Consumer(base.Consumer):
             self.log.dev('SEEK TO LATEST: %r', partition)
             self._consumer._subscription.need_offset_reset(
                 partition, OffsetResetStrategy.LATEST)
+        await self._consumer._fetcher.update_fetch_positions(partitions)
 
     async def seek_to_beginning(self, *partitions: TP) -> None:
         for partition in partitions:
             self.log.dev('SEEK TO BEGINNING: %r', partition)
             self._consumer._subscription.need_offset_reset(
                 partition, OffsetResetStrategy.EARLIEST)
+        await self._consumer._fetcher.update_fetch_positions(partitions)
 
     async def seek(self, partition: TP, offset: int) -> None:
         self.log.dev('SEEK %r -> %r', partition, offset)


### PR DESCRIPTION
Currently `seek_to_beginning`/`seek_to_latest` marks the `TP` for a seek but doesn't actually update its positions. This results in synchronization bugs as we use `seek_to_latest` to compute `highwaters` while recovering from changelogs. This was causing a deadlock upon recovery.

Now we wait until the positions have actually been updated.
