### PR TITLE
Create topics before subscribing

### DIFF
--- a/examples/simple.py
+++ b/examples/simple.py
@@ -36,7 +36,7 @@ app = faust.App(
     'f-simple2',
     url='kafka://127.0.0.1:9092',
     store='rocksdb://',
-    default_partitions=6,
+    default_partitions=4,
 )
 withdrawals_topic = app.topic('withdrawals2', value_type=Withdrawal)
 

--- a/faust/app.py
+++ b/faust/app.py
@@ -455,6 +455,7 @@ class App(AppT, ServiceProxy):
               deleting: bool = None,
               replicas: int = None,
               acks: bool = True,
+              internal: bool = False,
               config: Mapping[str, Any] = None) -> TopicT:
         """Create topic description.
 
@@ -478,6 +479,7 @@ class App(AppT, ServiceProxy):
             deleting=deleting,
             replicas=replicas,
             acks=acks,
+            internal=internal,
             config=config,
         )
 

--- a/faust/assignor/leader_assignor.py
+++ b/faust/assignor/leader_assignor.py
@@ -23,6 +23,7 @@ class LeaderAssignor(Service, LeaderAssignorT):
             self._leader_topic_name,
             partitions=1,
             acks=False,
+            internal=True,
         )
 
     @cached_property

--- a/faust/streams/stream.py
+++ b/faust/streams/stream.py
@@ -305,7 +305,8 @@ class Stream(StreamT, Service):
     def group_by(self, key: GroupByKeyArg,
                  *,
                  name: str = None,
-                 topic: TopicT = None) -> StreamT:
+                 topic: TopicT = None,
+                 partitions: int = None) -> StreamT:
         """Create new stream that repartitions the stream using a new key.
 
         Arguments:
@@ -369,7 +370,9 @@ class Stream(StreamT, Service):
             if not isinstance(self.channel, TopicT):
                 raise ValueError('Need to specify topic for non-topic channel')
             suffix = '-' + name + '-repartition'
-            topic = cast(TopicT, self.channel).derive(suffix=suffix)
+            p = self.app.default_partitions if partitions else partitions
+            topic = cast(TopicT, self.channel).derive(
+                suffix=suffix, partitions=p, internal=True)
         topic_created = False
         format_key = self._format_key
 

--- a/faust/tables/base.py
+++ b/faust/tables/base.py
@@ -234,6 +234,7 @@ class Collection(Service, CollectionT):
             compacting=compacting,
             deleting=deleting,
             acks=False,
+            internal=True,
         )
 
     def __copy__(self) -> Any:

--- a/faust/types/app.py
+++ b/faust/types/app.py
@@ -172,6 +172,7 @@ class AppT(ServiceT):
               deleting: bool = None,
               replicas: int = None,
               acks: bool = True,
+              internal: bool = False,
               config: Mapping[str, Any] = None) -> TopicT:
         ...
 

--- a/faust/types/topics.py
+++ b/faust/types/topics.py
@@ -34,6 +34,7 @@ class TopicT(ChannelT):
     replicas: int
     config: Mapping[str, Any]
     acks: bool
+    internal: bool
 
     @abc.abstractmethod
     def __init__(self, app: AppT,
@@ -49,6 +50,7 @@ class TopicT(ChannelT):
                  deleting: bool = None,
                  replicas: int = None,
                  acks: bool = True,
+                 internal: bool = False,
                  config: Mapping[str, Any] = None,
                  queue: asyncio.Queue = None,
                  errors: asyncio.Queue = None,
@@ -95,6 +97,7 @@ class TopicT(ChannelT):
                retention: Seconds = None,
                compacting: bool = None,
                deleting: bool = None,
+               internal: bool = False,
                config: Mapping[str, Any] = None,
                prefix: str = '',
                suffix: str = '') -> 'TopicT':


### PR DESCRIPTION
Fixes #36 .

The issue was the kafka-python creates the topic upon subscribing if the topic doesn't exist (if the kafka cluster is configure to auto create missing topics). We now first create topic before subscribing.

Updated leader assignor, table changelogs, and group_by topics to be `internal`. `internal` topics would be tried to be created before subscribing.
