### PR TITLE
Updating local consumer offsets when seeked

### DIFF
--- a/faust/tables/manager.py
+++ b/faust/tables/manager.py
@@ -96,12 +96,6 @@ class ChangelogReader(Service, ChangelogReaderT):
         earliest = {tp: offset - 1 for tp, offset in earliest.items()}
         for tp in self.tps:
             self.offsets[tp] = max(self.offsets[tp], earliest[tp])
-            # Set the updated offset in the consumer's offsets for bookkeeping
-            # We seek anyway but there seems to be a race condition with the
-            # aiokafka consumer having pre-fetched older messages
-            # Setting the offsets ensures that faust consumer will not
-            # deliver any stale messages
-            consumer._read_offset[tp] = self.offsets[tp]
         self.log.info(f'Updated offsets at start of reading: {self.offsets}')
 
     @Service.transitions_to(CHANGELOG_SEEKING)

--- a/faust/transport/aiokafka.py
+++ b/faust/transport/aiokafka.py
@@ -198,7 +198,7 @@ class Consumer(base.Consumer):
                 seek(tp, checkpoint)
             else:
                 self.log.dev('PERFORM SEEK AT BEGINNING TOPIC: %r', tp)
-                await self.seek_to_beginning(tp)
+                await self._seek_to_beginning(tp)
 
     async def _commit(self, offsets: Any) -> None:
         self.log.dev('COMMITTING OFFSETS: %r', offsets)
@@ -218,13 +218,7 @@ class Consumer(base.Consumer):
         for partition in tps:
             await self._consumer.position(partition)
 
-    async def seek_to_latest(self, *partitions: TP) -> None:
-        for partition in partitions:
-            self.log.dev('SEEK TO LATEST: %r', partition)
-            self._consumer._subscription.need_offset_reset(
-                partition, OffsetResetStrategy.LATEST)
-
-    async def seek_to_beginning(self, *partitions: TP) -> None:
+    async def _seek_to_beginning(self, *partitions: TP) -> None:
         for partition in partitions:
             self.log.dev('SEEK TO BEGINNING: %r', partition)
             self._consumer._subscription.need_offset_reset(
@@ -232,6 +226,7 @@ class Consumer(base.Consumer):
 
     async def seek(self, partition: TP, offset: int) -> None:
         self.log.dev('SEEK %r -> %r', partition, offset)
+        self._read_offset[partition] = offset
         self._consumer.seek(partition, offset)
 
     def assignment(self) -> Set[TP]:

--- a/faust/types/transports.py
+++ b/faust/types/transports.py
@@ -110,14 +110,6 @@ class ConsumerT(ServiceT):
         ...
 
     @abc.abstractmethod
-    async def seek_to_latest(self, *partitions: TP) -> None:
-        ...
-
-    @abc.abstractmethod
-    async def seek_to_beginning(self, *partitions: TP) -> None:
-        ...
-
-    @abc.abstractmethod
     async def seek(self, partition: TP, offset: int) -> None:
         ...
 


### PR DESCRIPTION
This bug was causing a deadlock, when we would seek offsets if the persisted offsets were ahead. In this case we could run into a race condition where we stop the changelog reader (hence no one is reading from the channel) but we do still end up trying to deliver the message to the channel because the local offsets int the faust consumer haven't been updated yet. This was causing the deadlock as no channel was available to read that message.