### PR TITLE
Add callback for changelog events read

### DIFF
--- a/examples/simple.py
+++ b/examples/simple.py
@@ -21,6 +21,8 @@ from datetime import datetime, timezone
 from itertools import count
 import faust
 from faust.cli import option
+from faust.types import EventT
+
 
 PRODUCE_LATENCY = float(os.environ.get('PRODUCE_LATENCY', 0.5))
 
@@ -40,8 +42,13 @@ app = faust.App(
 )
 withdrawals_topic = app.topic('withdrawals2', value_type=Withdrawal)
 
+
+async def print_key_value(event: EventT) -> None:
+    print(f'{event.key}{type(event.key)}:{event.value}{type(event.value)}')
+
 user_to_total = app.Table(
-    'user_to_total', default=int).tumbling(3600).relative_to_stream()
+    'user_to_total', default=int, on_changelog_event=print_key_value,
+).tumbling(3600).relative_to_stream()
 country_to_total = app.Table(
     'country_to_total', default=int).tumbling(10.0, expires=10.0)
 

--- a/faust/tables/manager.py
+++ b/faust/tables/manager.py
@@ -203,7 +203,8 @@ class ChangelogReader(Service, ChangelogReaderT):
         try:
             async for i, event in aenumerate(self._read_changelog()):
                 buf.append(event)
-                if len(buf) >= 1000:
+                await self.table.on_changelog_event(event)
+                if len(buf) >= self.table.recovery_buffer_size:
                     self.table.apply_changelog_batch(buf)
                     buf.clear()
                 if self._should_stop_reading():

--- a/faust/types/tables.py
+++ b/faust/types/tables.py
@@ -35,12 +35,14 @@ __all__ = [
     'WindowSetT',
     'WindowWrapperT',
     'ChangelogReaderT',
+    'ChangelogEventCallback',
     'CollectionTps',
 ]
 
 
 RelativeHandler = Callable[[Optional[EventT]], Union[float, datetime]]
 RecoverCallback = Callable[[], Awaitable[None]]
+ChangelogEventCallback = Callable[[EventT], Awaitable[None]]
 RelativeArg = Union[FieldDescriptorT, RelativeHandler, datetime, float]
 
 
@@ -55,6 +57,7 @@ class CollectionT(JoinableT, ServiceT):
     partitions: int
     window: WindowT = None
     help: str
+    recovery_buffer_size: int
 
     @abc.abstractmethod
     def __init__(self, app: AppT,
@@ -69,6 +72,8 @@ class CollectionT(JoinableT, ServiceT):
                  changelog_topic: TopicT = None,
                  help: str = None,
                  on_recover: RecoverCallback = None,
+                 on_changelog_event: ChangelogEventCallback = None,
+                 recovery_buffer_size: int = 1000,
                  **kwargs: Any) -> None:
         ...
 
@@ -103,6 +108,10 @@ class CollectionT(JoinableT, ServiceT):
 
     @abc.abstractmethod
     async def on_partitions_revoked(self, revoked: Iterable[TP]) -> None:
+        ...
+
+    @abc.abstractmethod
+    async def on_changelog_event(self, event: EventT) -> None:
         ...
 
     @abc.abstractmethod


### PR DESCRIPTION
Following two changes to make the changelog reader (and standbys):
- Ability to add a callback to be called for each changelog event read
- Make the changelog reading buffer size configurable