### PR TITLE
Add is_active and is_standby methods to the assignor

### DIFF
--- a/examples/simple.py
+++ b/examples/simple.py
@@ -21,7 +21,7 @@ from datetime import datetime, timezone
 from itertools import count
 import faust
 from faust.cli import option
-from faust.types import EventT
+from faust.types import EventT, TP
 
 
 PRODUCE_LATENCY = float(os.environ.get('PRODUCE_LATENCY', 0.5))
@@ -44,7 +44,9 @@ withdrawals_topic = app.topic('withdrawals2', value_type=Withdrawal)
 
 
 async def print_key_value(event: EventT) -> None:
-    print(f'{event.key}:{event.value}')
+    tp = TP(topic=event.message.topic, partition=event.message.partition)
+    if not app.assignor.is_active(tp):
+        print(f'{event.key}:{event.value}')
 
 user_to_total = app.Table(
     'user_to_total', default=int, on_changelog_event=print_key_value,

--- a/faust/assignor/client_assignment.py
+++ b/faust/assignor/client_assignment.py
@@ -2,6 +2,7 @@
 import copy
 from typing import List, MutableMapping, Sequence, Set, Tuple
 from faust.models import Record
+from faust.types import TP
 from faust.types.assignor import HostToPartitionMap
 from faust.types.tables import TableManagerT
 
@@ -84,6 +85,22 @@ class ClientAssignment(Record,
 
     actives: MutableMapping[str, List[int]]  # Topic -> Partition
     standbys: MutableMapping[str, List[int]]  # Topic -> Partition
+
+    @property
+    def active_tps(self) -> Set[TP]:
+        return self._get_tps(active=True)
+
+    @property
+    def standby_tps(self) -> Set[TP]:
+        return self._get_tps(active=False)
+
+    def _get_tps(self, active: bool) -> Set[TP]:
+        assignment = self.actives if active else self.standbys
+        return {
+            TP(topic=topic, partition=partition)
+            for topic, partitions in assignment.items()
+            for partition in partitions
+        }
 
     def kafka_protocol_assignment(
             self,

--- a/faust/types/assignor.py
+++ b/faust/types/assignor.py
@@ -29,6 +29,14 @@ class PartitionAssignorT(abc.ABC):
         ...
 
     @abc.abstractmethod
+    def is_active(self, tp: TP) -> bool:
+        ...
+
+    @abc.abstractmethod
+    def is_standby(self, tp: TP) -> bool:
+        ...
+
+    @abc.abstractmethod
     def key_store(self, topic: str, key: bytes) -> str:
         ...
 


### PR DESCRIPTION
Methods to see if a tp is active or standby.

Note: this PR introduces new methods that cache the actives and standbys as sets for efficient lookups. Previously these were only stored as lists for json serialization.