### PR TITLE
Allow tables to add extra configs for changelog topic

### DIFF
--- a/examples/simple.py
+++ b/examples/simple.py
@@ -51,6 +51,7 @@ async def print_key_value(event: EventT) -> None:
 user_to_total = app.Table(
     'user_to_total', default=int, on_changelog_event=print_key_value,
     standby_buffer_size=1, recovery_buffer_size=200,
+    extra_topic_configs={'min.cleanable.dirty.ratio': '0.01'},
 ).tumbling(3600).relative_to_stream()
 country_to_total = app.Table(
     'country_to_total', default=int).tumbling(10.0, expires=10.0)

--- a/faust/tables/base.py
+++ b/faust/tables/base.py
@@ -69,6 +69,7 @@ class Collection(Service, CollectionT):
                  on_changelog_event: ChangelogEventCallback = None,
                  recovery_buffer_size: int = 1000,
                  standby_buffer_size: int = None,
+                 extra_topic_configs: Mapping[str, Any] = None,
                  **kwargs: Any) -> None:
         Service.__init__(self, **kwargs)
         self.app = app
@@ -80,6 +81,7 @@ class Collection(Service, CollectionT):
         self.partitions = partitions
         self.window = window
         self.changelog_topic = changelog_topic
+        self.extra_topic_configs = extra_topic_configs or {}
         self.help = help
         self._on_changelog_event = on_changelog_event
         self.recovery_buffer_size = recovery_buffer_size
@@ -243,6 +245,7 @@ class Collection(Service, CollectionT):
             deleting=deleting,
             acks=False,
             internal=True,
+            config=self.extra_topic_configs,
         )
 
     def __copy__(self) -> Any:

--- a/faust/transport/aiokafka.py
+++ b/faust/transport/aiokafka.py
@@ -344,7 +344,7 @@ class Transport(base.Transport):
     def _topic_config(self,
                       retention: int = None,
                       compacting: bool = None,
-                      deleting: bool = None) -> Mapping[str, Any]:
+                      deleting: bool = None) -> MutableMapping[str, Any]:
         config: MutableMapping[str, Any] = {}
         cleanup_flags: Set[str] = set()
         if compacting:
@@ -393,7 +393,9 @@ class Transport(base.Transport):
                                    ensure_created: bool = False) -> None:
         owner.log.info(f'Creating topic {topic}')
         protocol_version = 1
-        config = config or self._topic_config(retention, compacting, deleting)
+        extra_configs = config or {}
+        config = self._topic_config(retention, compacting, deleting)
+        config.update(extra_configs)
 
         # Create topic request needs to be sent to the kafka cluster controller
         # Since aiokafka client doesn't currently support MetadataRequest

--- a/faust/types/tables.py
+++ b/faust/types/tables.py
@@ -4,8 +4,8 @@ import asyncio
 import typing
 from datetime import datetime
 from typing import (
-    Any, Awaitable, Callable, ClassVar, Iterable, List, MutableMapping,
-    MutableSet, Optional, Set, Type, Union,
+    Any, Awaitable, Callable, ClassVar, Iterable, List, Mapping,
+    MutableMapping, MutableSet, Optional, Set, Type, Union,
 )
 from mode import Seconds, ServiceT
 from mode.utils.compat import Counter
@@ -76,6 +76,7 @@ class CollectionT(JoinableT, ServiceT):
                  on_changelog_event: ChangelogEventCallback = None,
                  recovery_buffer_size: int = 1000,
                  standby_buffer_size: int = None,
+                 extra_topic_configs: Mapping[str, Any] = None,
                  **kwargs: Any) -> None:
         ...
 


### PR DESCRIPTION
Tables might sometimes want to use some of the advanced configs of kafka for the changelog topics. This allows the ability to set arbitrary configurations in addition to the once set by Faust.

See: #57 