### PR TITLE
[docs] Add FAQ answer for maximum open files exceeded issue

### DIFF
--- a/docs/includes/faq.txt
+++ b/docs/includes/faq.txt
@@ -128,6 +128,6 @@ I get a maximum number of open files exceeded error by RocksDB when running a
 Faust app locally. How can I fix this?
 --------------------------
 
-You need to increase the limit for the maximum number of open files. The
+You may need to increase the limit for the maximum number of open files. The
 following post explains how to do so on OS X:
 https://blog.dekstroza.io/ulimit-shenanigans-on-osx-el-capitan/


### PR DESCRIPTION
## Description

Documentation seems to be missing for this commonly encountered error. This should fix that issue. 