### PR TITLE
Fix acking multiple agents

### DIFF
--- a/examples/withdrawals.py
+++ b/examples/withdrawals.py
@@ -57,7 +57,7 @@ async def track_user_withdrawal(withdrawals):
 @app.agent(withdrawals_topic)
 async def track_country_withdrawal(withdrawals):
     async for withdrawal in withdrawals.group_by(Withdrawal.country):
-        country_to_total[withdrawals.country] += withdrawal.amount
+        country_to_total[withdrawal.country] += withdrawal.amount
 
 
 @app.command(

--- a/faust/channels.py
+++ b/faust/channels.py
@@ -84,7 +84,6 @@ class Event(EventT):
         self.key: K = key
         self.value: V = value
         self.message: Message = message
-        self.acked: bool = False
 
     async def send(self, channel: Union[str, ChannelT],
                    key: K = USE_EXISTING_KEY,
@@ -157,7 +156,6 @@ class Event(EventT):
     async def ack(self) -> None:
         message = self.message
         if message.refcount:
-            self.acked = True
             # decrement the reference count
             message.decref()
             # if no more references, ack message


### PR DESCRIPTION
Due to this we were not acking messages ever if multiple agents were subscribed to a stream.

Looks like the self.acked was only being used for this purpose. Not sure if this was added for some reason.