### PR TITLE
Optimize perform_seek to be faster

### DIFF
--- a/faust/transport/aiokafka.py
+++ b/faust/transport/aiokafka.py
@@ -264,6 +264,7 @@ class Consumer(base.Consumer):
         offsets = zip(tps, wait_res.result)
         committed_offsets = dict(filter(lambda x: x[1] is not None, offsets))
         read_offset.update(committed_offsets)
+        self._committed_offset.update(committed_offsets)
 
     async def _commit(self, tp: TP, offset: int, meta: str) -> None:
         self.log.dev('COMMITTING OFFSETS: tp=%r offset=%r', tp, offset)


### PR DESCRIPTION
Currently `perform_seek` runs super slow. This is because we go and seek per topic sequentially. This has a huge overhead. Further we don't really need to do this because there is an aiokafka method to do this en bulk: https://github.com/aio-libs/aiokafka/blob/9659b380c9a28923fe3ae3137784dff411686dfe/aiokafka/consumer/consumer.py#L666-L673  This does exactly what the method was initially doing i.e. seeking to committed for all topic partitions for which we have a committed offset. We also update the read offsets with these offsets.

For topics partitions that we have never committed before, we default to beginning of the log because of the following setting: https://github.com/robinhoodmarkets/faust/blob/master/faust/transport/aiokafka.py#L142

With edgy, which has close to 800 partitions (8 topics * 100 partitions each), this method was taking ~15 mins but then came down to ~ 1 sec with this change.
