### PR TITLE
Fix timezone parsing error

### DIFF
--- a/faust/utils/iso8601.py
+++ b/faust/utils/iso8601.py
@@ -74,4 +74,4 @@ def _apply_tz_prefix(prefix: str, hours: int, minutes: int) -> tzinfo:
     if prefix == '-':
         hours = -hours
         minutes = -minutes
-    return timezone(timedelta(minutes + hours * 60))
+    return timezone(timedelta(minutes=(minutes + (hours * 60))))


### PR DESCRIPTION
Default first parameter for `timedelta` is hours. We want minutes here.