### PR TITLE
Fix dead links in docs and add highlighting

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -838,7 +838,7 @@ Packages
 :CI: http://travis-ci.org/#!/robinhood/faust
 :Windows-CI: https://ci.appveyor.com/project/ask/faust
 :PyPI: ``faust``
-:docs: http://docs.fauststream.com
+:docs: https://faust.readthedocs.io
 
 ``Mode``
 --------
@@ -911,7 +911,7 @@ following:
 
 .. _`mailing-list`: https://groups.google.com/group/faust-users
 
-.. _`slack-channel`: http://docs.fauststream.com/en/latest/getting-started/resources.html#slack-channel
+.. _`slack-channel`: https://faust.readthedocs.io/en/latest/introduction.html#slack
 
-.. _`report an issue`: http://docs.fauststream.com/en/latest/contributing.html#reporting-bugs
+.. _`report an issue`: https://faust.readthedocs.io/en/latest/introduction.html#bug-tracker
 

--- a/README.rst
+++ b/README.rst
@@ -176,7 +176,9 @@ Faust is...
     the rest is just Python, so If you know Python you can already use Faust to do
     stream processing, and it can integrate with just about anything.
 
-    Here's one of the easier applications you can make::
+    Here's one of the easier applications you can make:
+
+    .. sourcecode:: python
 
         import faust
 
@@ -560,7 +562,7 @@ Be sure to also read the `Contributing to Faust`_ section in the
 documentation.
 
 .. _`Contributing to Faust`:
-    http://docs.fauststream.com/en/master/contributing.html
+    https://faust.readthedocs.io/en/latest/contributing.html
 
 Code of Conduct
 ===============

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,7 +45,7 @@ globals().update(conf.build_config(
     project='Faust',
     # version_dev='2.0',
     # version_stable='1.4',
-    canonical_url='http://docs.fauststream.com',
+    canonical_url='http://faust.readthedocs.io',
     webdomain='',
     github_project='robinhood/faust',
     copyright='2017-2018',

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -796,7 +796,7 @@ Packages
 :CI: http://travis-ci.org/#!/robinhood/faust
 :Windows-CI: https://ci.appveyor.com/project/ask/faust
 :PyPI: :pypi:`faust`
-:docs: http://docs.fauststream.com
+:docs: https://faust.readthedocs.io
 
 ``Mode``
 --------

--- a/docs/templates/readme.txt
+++ b/docs/templates/readme.txt
@@ -42,7 +42,7 @@ Be sure to also read the `Contributing to Faust`_ section in the
 documentation.
 
 .. _`Contributing to Faust`:
-    http://docs.fauststream.com/en/master/contributing.html
+    http://faust.readthedocs.io/en/latest/contributing.html
 
 .. include:: ../includes/code-of-conduct.txt
 


### PR DESCRIPTION
## Description

After being linked from HN I found a couple dead links in the docs. Also added a source code directive for a python block

- [x] squash before merging