### PR TITLE
Add consumer stats to the Monitor

### DIFF
--- a/faust/sensors/monitor.py
+++ b/faust/sensors/monitor.py
@@ -25,8 +25,8 @@ MAX_COMMIT_LATENCY_HISTORY = 30
 MAX_SEND_LATENCY_HISTORY = 30
 
 TPOffsetMapping = MutableMapping[TP, int]
-PartitionOffsetMapping = Mapping[int, int]
-TPOffsetDict = Mapping[str, PartitionOffsetMapping]
+PartitionOffsetMapping = MutableMapping[int, int]
+TPOffsetDict = MutableMapping[str, PartitionOffsetMapping]
 
 
 class TableState(KeywordReduce):
@@ -253,7 +253,7 @@ class Monitor(ServiceProxy, Sensor, KeywordReduce):
 
     @classmethod
     def _tp_offsets_as_dict(cls, tp_offsets: TPOffsetMapping) -> TPOffsetDict:
-        topic_partition_offsets = {}
+        topic_partition_offsets: TPOffsetDict = {}
         for tp, offset in tp_offsets.items():
             partition_offsets = topic_partition_offsets.get(tp.topic, {})
             partition_offsets[tp.partition] = offset

--- a/faust/sensors/monitor.py
+++ b/faust/sensors/monitor.py
@@ -24,9 +24,9 @@ MAX_AVG_HISTORY = 100
 MAX_COMMIT_LATENCY_HISTORY = 30
 MAX_SEND_LATENCY_HISTORY = 30
 
-TP_OFFSETS = MutableMapping[TP, int]
-PARTITION_OFFSETS_DICT = Mapping[int, int]
-TP_OFFSETS_DICT = Mapping[str, PARTITION_OFFSETS_DICT]
+TPOffsetMapping = MutableMapping[TP, int]
+PartitionOffsetMapping = Mapping[int, int]
+TPOffsetDict = Mapping[str, PartitionOffsetMapping]
 
 
 class TableState(KeywordReduce):
@@ -140,13 +140,13 @@ class Monitor(ServiceProxy, Sensor, KeywordReduce):
     metric_counts: Counter[str] = cast(Counter[str], None)
 
     #: Last committed offsets by TopicPartition
-    tp_committed_offsets: TP_OFFSETS = cast(TP_OFFSETS, None)
+    tp_committed_offsets: TPOffsetMapping = cast(TPOffsetMapping, None)
 
     #: Last read offsets by TopicPartition
-    tp_read_offsets: TP_OFFSETS = cast(TP_OFFSETS, None)
+    tp_read_offsets: TPOffsetMapping = cast(TPOffsetMapping, None)
 
     #: Log end offsets by TopicPartition
-    tp_end_offsets: TP_OFFSETS = cast(TP_OFFSETS, None)
+    tp_end_offsets: TPOffsetMapping = cast(TPOffsetMapping, None)
 
     def __init__(self,
                  *,
@@ -242,19 +242,17 @@ class Monitor(ServiceProxy, Sensor, KeywordReduce):
     def _metric_counts_dict(self) -> MutableMapping[str, int]:
         return {key: count for key, count in self.metric_counts.items()}
 
-    def _tp_committed_offsets_dict(self) -> TP_OFFSETS_DICT:
-        return self._tp_offsets_as_dic(self.tp_committed_offsets)
+    def _tp_committed_offsets_dict(self) -> TPOffsetDict:
+        return self._tp_offsets_as_dict(self.tp_committed_offsets)
 
-    def _tp_read_offsets_dict(self) -> TP_OFFSETS_DICT:
-        return self._tp_offsets_as_dic(self.tp_read_offsets)
+    def _tp_read_offsets_dict(self) -> TPOffsetDict:
+        return self._tp_offsets_as_dict(self.tp_read_offsets)
 
-    def _tp_end_offsets_dict(self) -> TP_OFFSETS_DICT:
-        return self._tp_offsets_as_dic(self.tp_end_offsets)
+    def _tp_end_offsets_dict(self) -> TPOffsetDict:
+        return self._tp_offsets_as_dict(self.tp_end_offsets)
 
     @classmethod
-    def _tp_offsets_as_dic(cls,
-                           tp_offsets: TP_OFFSETS,
-                           ) -> Mapping[str, Mapping[int, int]]:
+    def _tp_offsets_as_dict(cls, tp_offsets: TPOffsetMapping) -> TPOffsetDict:
         topic_partition_offsets = {}
         for tp, offset in tp_offsets.items():
             partition_offsets = topic_partition_offsets.get(tp.topic, {})

--- a/faust/sensors/monitor.py
+++ b/faust/sensors/monitor.py
@@ -145,8 +145,8 @@ class Monitor(ServiceProxy, Sensor, KeywordReduce):
     #: Last read offsets by TopicPartition
     tp_read_offsets: TP_OFFSETS = cast(TP_OFFSETS, None)
 
-    #: Last seen highwaters by TopicPartition
-    tp_highwaters: TP_OFFSETS = cast(TP_OFFSETS, None)
+    #: Log end offsets by TopicPartition
+    tp_end_offsets: TP_OFFSETS = cast(TP_OFFSETS, None)
 
     def __init__(self,
                  *,
@@ -199,7 +199,7 @@ class Monitor(ServiceProxy, Sensor, KeywordReduce):
 
         self.tp_committed_offsets = {}
         self.tp_read_offsets = {}
-        self.tp_highwaters = {}
+        self.tp_end_offsets = {}
 
     def asdict(self) -> Mapping:
         return {
@@ -224,7 +224,7 @@ class Monitor(ServiceProxy, Sensor, KeywordReduce):
             'metric_counts': self._metric_counts_dict(),
             'topic_committed_offsets': self._tp_committed_offsets_dict(),
             'topic_read_offsets': self._tp_read_offsets_dict(),
-            'topic_highwaters': self._tp_highwaters_dict(),
+            'topic_end_offsets': self._tp_end_offsets_dict(),
         }
 
     def _events_by_stream_dict(self) -> MutableMapping[str, int]:
@@ -248,8 +248,8 @@ class Monitor(ServiceProxy, Sensor, KeywordReduce):
     def _tp_read_offsets_dict(self) -> TP_OFFSETS_DICT:
         return self._tp_offsets_as_dic(self.tp_read_offsets)
 
-    def _tp_highwaters_dict(self) -> TP_OFFSETS_DICT:
-        return self._tp_offsets_as_dic(self.tp_highwaters)
+    def _tp_end_offsets_dict(self) -> TP_OFFSETS_DICT:
+        return self._tp_offsets_as_dic(self.tp_end_offsets)
 
     @classmethod
     def _tp_offsets_as_dic(cls,
@@ -373,11 +373,11 @@ class Monitor(ServiceProxy, Sensor, KeywordReduce):
             if offset is not None
         })
 
-    def track_tp_highwater(self, tp_highwaters: Mapping[TP, int]) -> None:
-        self.tp_highwaters.update({
-            tp: highwater
-            for tp, highwater in tp_highwaters.items()
-            if highwater is not None
+    def track_tp_end_offsets(self, tp_end_offsets: Mapping[TP, int]) -> None:
+        self.tp_end_offsets.update({
+            tp: end_offset
+            for tp, end_offset in tp_end_offsets.items()
+            if end_offset is not None
         })
 
     @cached_property

--- a/faust/sensors/monitor.py
+++ b/faust/sensors/monitor.py
@@ -255,7 +255,7 @@ class Monitor(ServiceProxy, Sensor, KeywordReduce):
     def _tp_offsets_as_dict(cls, tp_offsets: TPOffsetMapping) -> TPOffsetDict:
         topic_partition_offsets: TPOffsetDict = {}
         for tp, offset in tp_offsets.items():
-            partition_offsets = topic_partition_offsets.get(tp.topic, {})
+            partition_offsets = topic_partition_offsets.get(tp.topic) or {}
             partition_offsets[tp.partition] = offset
             topic_partition_offsets[tp.topic] = partition_offsets
         return topic_partition_offsets
@@ -364,19 +364,11 @@ class Monitor(ServiceProxy, Sensor, KeywordReduce):
     def count(self, metric_name: str, count: int = 1) -> None:
         self.metric_counts[metric_name] += count
 
-    def on_tp_commit(self, tp_offsets: Mapping[TP, int]) -> None:
-        self.tp_committed_offsets.update({
-            tp: offset
-            for tp, offset in tp_offsets.items()
-            if offset is not None
-        })
+    def on_tp_commit(self, tp_offsets: TPOffsetMapping) -> None:
+        self.tp_committed_offsets.update(tp_offsets)
 
-    def track_tp_end_offsets(self, tp_end_offsets: Mapping[TP, int]) -> None:
-        self.tp_end_offsets.update({
-            tp: end_offset
-            for tp, end_offset in tp_end_offsets.items()
-            if end_offset is not None
-        })
+    def track_tp_end_offsets(self, tp_end_offsets: TPOffsetMapping) -> None:
+        self.tp_end_offsets.update(tp_end_offsets)
 
     @cached_property
     def _service(self) -> ServiceT:

--- a/faust/sensors/monitor.py
+++ b/faust/sensors/monitor.py
@@ -24,6 +24,10 @@ MAX_AVG_HISTORY = 100
 MAX_COMMIT_LATENCY_HISTORY = 30
 MAX_SEND_LATENCY_HISTORY = 30
 
+TP_OFFSETS = MutableMapping[TP, int]
+PARTITION_OFFSETS_DICT = Mapping[int, int]
+TP_OFFSETS_DICT = Mapping[str, PARTITION_OFFSETS_DICT]
+
 
 class TableState(KeywordReduce):
     """Represents the current state of a table."""
@@ -135,6 +139,15 @@ class Monitor(ServiceProxy, Sensor, KeywordReduce):
     #: Arbitrary counts added by apps
     metric_counts: Counter[str] = cast(Counter[str], None)
 
+    #: Last committed offsets by TopicPartition
+    tp_committed_offsets: TP_OFFSETS = cast(TP_OFFSETS, None)
+
+    #: Last read offsets by TopicPartition
+    tp_read_offsets: TP_OFFSETS = cast(TP_OFFSETS, None)
+
+    #: Last seen highwaters by TopicPartition
+    tp_highwaters: TP_OFFSETS = cast(TP_OFFSETS, None)
+
     def __init__(self,
                  *,
                  max_avg_history: int = MAX_AVG_HISTORY,
@@ -184,6 +197,10 @@ class Monitor(ServiceProxy, Sensor, KeywordReduce):
 
         self.metric_counts = Counter()
 
+        self.tp_committed_offsets = {}
+        self.tp_read_offsets = {}
+        self.tp_highwaters = {}
+
     def asdict(self) -> Mapping:
         return {
             'messages_active': self.messages_active,
@@ -205,6 +222,9 @@ class Monitor(ServiceProxy, Sensor, KeywordReduce):
                 name: table.asdict() for name, table in self.tables.items()
             },
             'metric_counts': self._metric_counts_dict(),
+            'topic_committed_offsets': self._tp_committed_offsets_dict(),
+            'topic_read_offsets': self._tp_read_offsets_dict(),
+            'topic_highwaters': self._tp_highwaters_dict(),
         }
 
     def _events_by_stream_dict(self) -> MutableMapping[str, int]:
@@ -221,6 +241,26 @@ class Monitor(ServiceProxy, Sensor, KeywordReduce):
 
     def _metric_counts_dict(self) -> MutableMapping[str, int]:
         return {key: count for key, count in self.metric_counts.items()}
+
+    def _tp_committed_offsets_dict(self) -> TP_OFFSETS_DICT:
+        return self._tp_offsets_as_dic(self.tp_committed_offsets)
+
+    def _tp_read_offsets_dict(self) -> TP_OFFSETS_DICT:
+        return self._tp_offsets_as_dic(self.tp_read_offsets)
+
+    def _tp_highwaters_dict(self) -> TP_OFFSETS_DICT:
+        return self._tp_offsets_as_dic(self.tp_highwaters)
+
+    @classmethod
+    def _tp_offsets_as_dic(cls,
+                           tp_offsets: TP_OFFSETS,
+                           ) -> Mapping[str, Mapping[int, int]]:
+        topic_partition_offsets = {}
+        for tp, offset in tp_offsets.items():
+            partition_offsets = topic_partition_offsets.get(tp.topic, {})
+            partition_offsets[tp.partition] = offset
+            topic_partition_offsets[tp.topic] = partition_offsets
+        return topic_partition_offsets
 
     def _cleanup(self) -> None:
         self._cleanup_max_avg_history()
@@ -251,6 +291,7 @@ class Monitor(ServiceProxy, Sensor, KeywordReduce):
         self.messages_received_total += 1
         self.messages_active += 1
         self.messages_received_by_topic[tp.topic] += 1
+        self.tp_read_offsets[tp] = offset
         message.time_in = self.time()
 
     def on_stream_event_in(self, tp: TP, offset: int, stream: StreamT,
@@ -324,6 +365,20 @@ class Monitor(ServiceProxy, Sensor, KeywordReduce):
 
     def count(self, metric_name: str, count: int = 1) -> None:
         self.metric_counts[metric_name] += count
+
+    def on_tp_commit(self, tp_offsets: Mapping[TP, int]) -> None:
+        self.tp_committed_offsets.update({
+            tp: offset
+            for tp, offset in tp_offsets.items()
+            if offset is not None
+        })
+
+    def track_tp_highwater(self, tp_highwaters: Mapping[TP, int]) -> None:
+        self.tp_highwaters.update({
+            tp: highwater
+            for tp, highwater in tp_highwaters.items()
+            if highwater is not None
+        })
 
     @cached_property
     def _service(self) -> ServiceT:

--- a/faust/sensors/statsd.py
+++ b/faust/sensors/statsd.py
@@ -2,7 +2,7 @@
 import re
 import typing
 from time import monotonic
-from typing import Any, Mapping, Pattern, cast
+from typing import Any, Pattern, cast
 
 from mode.utils.objects import cached_property
 

--- a/faust/sensors/statsd.py
+++ b/faust/sensors/statsd.py
@@ -145,11 +145,11 @@ class StatsdMonitor(Monitor):
             metric_name = f'committed.{tp.topic}.{tp.partition}'
             self.client.gauge(metric_name, offset)
 
-    def track_tp_highwater(self, tp_highwaters: Mapping[TP, int]) -> None:
-        super().on_tp_commit(tp_highwaters)
-        for tp, highwater in tp_highwaters.items():
-            metric_name = f'highwater.{tp.topic}.{tp.partition}'
-            self.client.gauge(metric_name, highwater)
+    def track_tp_end_offsets(self, tp_end_offsets: Mapping[TP, int]) -> None:
+        super().on_tp_commit(tp_end_offsets)
+        for tp, end_offset in tp_end_offsets.items():
+            metric_name = f'end_offset.{tp.topic}.{tp.partition}'
+            self.client.gauge(metric_name, end_offset)
 
     def _normalize(self, name: str,
                    *,

--- a/faust/sensors/statsd.py
+++ b/faust/sensors/statsd.py
@@ -10,7 +10,7 @@ from faust.exceptions import ImproperlyConfigured
 from faust.types import CollectionT, EventT, Message, StreamT, TP
 from faust.types.transports import ConsumerT, ProducerT
 
-from .monitor import Monitor
+from .monitor import Monitor, TPOffsetMapping
 
 try:
     import statsd
@@ -139,13 +139,13 @@ class StatsdMonitor(Monitor):
         super().count(metric_name, count=count)
         self.client.incr(metric_name, count=count, rate=self.rate)
 
-    def on_tp_commit(self, tp_offsets: Mapping[TP, int]) -> None:
+    def on_tp_commit(self, tp_offsets: TPOffsetMapping) -> None:
         super().on_tp_commit(tp_offsets)
         for tp, offset in tp_offsets.items():
             metric_name = f'committed_offset.{tp.topic}.{tp.partition}'
             self.client.gauge(metric_name, offset)
 
-    def track_tp_end_offsets(self, tp_end_offsets: Mapping[TP, int]) -> None:
+    def track_tp_end_offsets(self, tp_end_offsets: TPOffsetMapping) -> None:
         super().on_tp_commit(tp_end_offsets)
         for tp, end_offset in tp_end_offsets.items():
             metric_name = f'end_offset.{tp.topic}.{tp.partition}'

--- a/faust/sensors/statsd.py
+++ b/faust/sensors/statsd.py
@@ -70,7 +70,7 @@ class StatsdMonitor(Monitor):
         self.client.incr('messages_received', rate=self.rate)
         self.client.incr('messages_active', rate=self.rate)
         self.client.incr(f'topic.{tp.topic}.messages_received', rate=self.rate)
-        self.client.gauge(f'read.{tp.topic}.{tp.partition}', offset)
+        self.client.gauge(f'read_offset.{tp.topic}.{tp.partition}', offset)
 
     def on_stream_event_in(self, tp: TP, offset: int, stream: StreamT,
                            event: EventT) -> None:
@@ -142,7 +142,7 @@ class StatsdMonitor(Monitor):
     def on_tp_commit(self, tp_offsets: Mapping[TP, int]) -> None:
         super().on_tp_commit(tp_offsets)
         for tp, offset in tp_offsets.items():
-            metric_name = f'committed.{tp.topic}.{tp.partition}'
+            metric_name = f'committed_offset.{tp.topic}.{tp.partition}'
             self.client.gauge(metric_name, offset)
 
     def track_tp_end_offsets(self, tp_end_offsets: Mapping[TP, int]) -> None:

--- a/faust/transport/consumer.py
+++ b/faust/transport/consumer.py
@@ -538,8 +538,8 @@ class Consumer(Service, ConsumerT):
     async def record_end_offsets(self) -> None:
         interval = self._end_offset_monitor_interval
         while not self.should_stop:
+            await self.sleep(interval)
             partitions = self.assignment()
             if partitions:
                 end_offsets = await self.highwaters(*partitions)
                 self.app.monitor.track_tp_end_offsets(end_offsets)
-            await self.sleep(interval)

--- a/faust/transport/consumer.py
+++ b/faust/transport/consumer.py
@@ -188,6 +188,9 @@ class Consumer(Service, ConsumerT):
     #: Time of when the consumer was started.
     _time_start: float
 
+    # How often to poll and track highwaters
+    _highwater_monitor_interval: int
+
     _commit_every: Optional[int]
     _n_acked: int = 0
 
@@ -222,6 +225,7 @@ class Consumer(Service, ConsumerT):
         self._waiting_for_ack = None
         self._time_start = monotonic()
         self._last_batch = None
+        self._highwater_monitor_interval = self.commit_interval * 2
         self.randomly_assigned_topics = set()
         super().__init__(loop=loop or self.transport.loop, **kwargs)
 
@@ -529,3 +533,13 @@ class Consumer(Service, ConsumerT):
     @property
     def unacked(self) -> Set[Message]:
         return cast(Set[Message], self._unacked_messages)
+
+    @Service.task
+    async def record_highwaters(self) -> None:
+        interval = self._highwater_monitor_interval
+        while not self.should_stop:
+            partitions = self.assignment()
+            if partitions:
+                highwaters = await self.highwaters(*partitions)
+                self.app.monitor.track_tp_highwater(highwaters)
+            await self.sleep(interval)

--- a/faust/transport/consumer.py
+++ b/faust/transport/consumer.py
@@ -189,7 +189,7 @@ class Consumer(Service, ConsumerT):
     _time_start: float
 
     # How often to poll and track log end offsets.
-    _end_offset_monitor_interval: int
+    _end_offset_monitor_interval: float
 
     _commit_every: Optional[int]
     _n_acked: int = 0

--- a/faust/transport/drivers/aiokafka.py
+++ b/faust/transport/drivers/aiokafka.py
@@ -525,6 +525,7 @@ class Consumer(base.Consumer):
                 await self._consumer.commit(commitable)
                 on_timeout.info('-aiokafka._consumer.commit()')
             self._committed_offset.update(commitable_offsets)
+            self.app.monitor.on_tp_commit(commitable_offsets)
             self._last_batch = None
             return True
         except CommitFailedError as exc:


### PR DESCRIPTION
## Description

Adding the following consumer stats to the monitor:
- Last read offset for each Topic Partition
- Last committed offset for each Topic Partition
- Log end offset for each Topic Partition (we poll this at an interval in the background)

Add these to the StatsdMonitor as well.

Tested locally with the word count example.