### PR TITLE
Better topic creation

### DIFF
--- a/examples/word_count.py
+++ b/examples/word_count.py
@@ -43,6 +43,8 @@ async def get_count(web, request):
 
 @app.task
 async def sender():
+    await posts_topic.maybe_declare()
+
     for word in WORDS:
         for _ in range(1000):
             await shuffle_words.send(value=word)

--- a/faust/transport/drivers/aiokafka.py
+++ b/faust/transport/drivers/aiokafka.py
@@ -756,7 +756,7 @@ class Transport(base.Transport):
             )
             if wait_result.stopped:
                 owner.log.info(f'Shutting down - skipping creation.')
-                return
+                return None
             response = wait_result.result
             return response.controller_id
         raise Exception(f'Controller node not found')

--- a/faust/transport/drivers/aiokafka.py
+++ b/faust/transport/drivers/aiokafka.py
@@ -785,11 +785,11 @@ class Transport(base.Transport):
         config = self._topic_config(retention, compacting, deleting)
         config.update(extra_configs)
 
-        controlled_node = await self._get_controller_node(owner, client,
+        controller_node = await self._get_controller_node(owner, client,
                                                           timeout=timeout)
-        owner.log.info(f'Found controller: {controlled_node}')
+        owner.log.info(f'Found controller: {controller_node}')
 
-        if controlled_node is None:
+        if controller_node is None:
             if owner.should_stop:
                 owner.log.info(f'Shutting down hence controller not found')
                 return
@@ -802,7 +802,7 @@ class Transport(base.Transport):
             False,
         )
         wait_result = await owner.wait(
-            client.send(controlled_node, request),
+            client.send(controller_node, request),
             timeout=timeout,
         )
         if wait_result.stopped:
@@ -820,7 +820,7 @@ class Transport(base.Transport):
                     f'Topic {topic} exists, skipping creation.')
                 return
             elif code == NotControllerError.errno:
-                raise RuntimeError(f'Invalid controller: {controlled_node}')
+                raise RuntimeError(f'Invalid controller: {controller_node}')
             else:
                 raise for_code(code)(
                     f'Cannot create topic: {topic} ({code}): {reason}')

--- a/faust/transport/drivers/aiokafka.py
+++ b/faust/transport/drivers/aiokafka.py
@@ -775,6 +775,11 @@ class Transport(base.Transport):
                                    deleting: bool = None,
                                    ensure_created: bool = False) -> None:
         owner.log.info(f'Creating topic {topic}')
+
+        if topic in client.cluster.topics():
+            owner.log.debug(f'Topic {topic} exists, skipping creation.')
+            return
+
         protocol_version = 1
         extra_configs = config or {}
         config = self._topic_config(retention, compacting, deleting)


### PR DESCRIPTION
## Description

Topic creation was added to the aiokafka transport by using the client to send the CreateTopicRequest. At the time of working on this, we went through all available nodes until we found the controller. This is super inefficient.

Now we do the following:
- First, check if topic is in bootstrapped cluster metadata
- If not already in metadata, we next send a MetadataRequest to the first available node to get the controller_id
- We now send the CreateTopic request to the controller directly

This largely reduces the number of requests and the complexity of topic creation.

Tested this locally using single broker kafka as well on the dev cluster using multi broker kafka cluster.