### PR TITLE
Better metrics tracking for highwaters

### DIFF
--- a/faust/sensors/monitor.py
+++ b/faust/sensors/monitor.py
@@ -367,8 +367,8 @@ class Monitor(ServiceProxy, Sensor, KeywordReduce):
     def on_tp_commit(self, tp_offsets: TPOffsetMapping) -> None:
         self.tp_committed_offsets.update(tp_offsets)
 
-    def track_tp_end_offsets(self, tp_end_offsets: TPOffsetMapping) -> None:
-        self.tp_end_offsets.update(tp_end_offsets)
+    def track_tp_end_offset(self, tp: TP, offset: int) -> None:
+        self.tp_end_offsets[tp] = offset
 
     @cached_property
     def _service(self) -> ServiceT:

--- a/faust/sensors/statsd.py
+++ b/faust/sensors/statsd.py
@@ -145,11 +145,10 @@ class StatsdMonitor(Monitor):
             metric_name = f'committed_offset.{tp.topic}.{tp.partition}'
             self.client.gauge(metric_name, offset)
 
-    def track_tp_end_offsets(self, tp_end_offsets: TPOffsetMapping) -> None:
-        super().on_tp_commit(tp_end_offsets)
-        for tp, end_offset in tp_end_offsets.items():
-            metric_name = f'end_offset.{tp.topic}.{tp.partition}'
-            self.client.gauge(metric_name, end_offset)
+    def track_tp_end_offset(self, tp: TP, offset: int) -> None:
+        super().track_tp_end_offset(tp, offset)
+        metric_name = f'end_offset.{tp.topic}.{tp.partition}'
+        self.client.gauge(metric_name, offset)
 
     def _normalize(self, name: str,
                    *,

--- a/faust/transport/consumer.py
+++ b/faust/transport/consumer.py
@@ -533,13 +533,3 @@ class Consumer(Service, ConsumerT):
     @property
     def unacked(self) -> Set[Message]:
         return cast(Set[Message], self._unacked_messages)
-
-    @Service.task
-    async def record_end_offsets(self) -> None:
-        interval = self._end_offset_monitor_interval
-        while not self.should_stop:
-            await self.sleep(interval)
-            partitions = self.assignment()
-            if partitions:
-                end_offsets = await self.highwaters(*partitions)
-                self.app.monitor.track_tp_end_offsets(end_offsets)

--- a/faust/transport/drivers/aiokafka.py
+++ b/faust/transport/drivers/aiokafka.py
@@ -436,6 +436,8 @@ class Consumer(base.Consumer):
                     to_remove.add(topic)
                     continue
                 tp, record = item  # type: ignore
+                highwater_mark = self._consumer.highwater(tp)
+                self.app.monitor.track_tp_end_offset(tp, highwater_mark)
                 yield tp, create_message(
                     record.topic,
                     record.partition,

--- a/t/unit/sensors/test_monitor.py
+++ b/t/unit/sensors/test_monitor.py
@@ -289,16 +289,12 @@ class test_Monitor:
             assert all(offsets_dict[p] == offset for p in partitions)
 
     def test_track_tp_end_offsets(self, *, mon):
-        topic = "foo"
+        tp = TP(topic="foo", partition=2)
         for offset in range(20):
-            partitions = list(range(4))
-            tps = {TP(topic=topic, partition=p) for p in partitions}
-            log_end_offsets = {tp: offset for tp in tps}
-            mon.track_tp_end_offsets(log_end_offsets)
-            assert all(mon.tp_end_offsets[tp] == log_end_offsets[tp]
-                       for tp in tps)
-            offsets_dict = mon.asdict()["topic_end_offsets"][topic]
-            assert all(offsets_dict[p] == offset for p in partitions)
+            mon.track_tp_end_offset(tp, offset)
+            assert mon.tp_end_offsets[tp] == offset
+            offsets_dict = mon.asdict()["topic_end_offsets"][tp.topic]
+            assert offsets_dict[tp.partition] == offset
 
     @pytest.mark.asyncio
     async def test_service_sampler(self, *, mon):

--- a/t/unit/transport/test_consumer.py
+++ b/t/unit/transport/test_consumer.py
@@ -365,22 +365,3 @@ class test_Consumer:
             call(consumer.commit_interval),
         ])
         consumer.commit.assert_called_once_with()
-
-    @pytest.mark.asyncio
-    async def test_record_end_offsets(self, *, consumer):
-
-        def on_sleep(secs):
-            consumer._stopped.set()
-
-        assignment = {TP1, TP2}
-        highwaters = {TP1: 12, TP2: 23}
-        consumer.sleep = AsyncMock(name='sleep', side_effect=on_sleep)
-        consumer.highwaters = AsyncMock(name='highwaters',
-                                        return_value=highwaters)
-        consumer.assignment = Mock(name='assignment', return_value=assignment)
-
-        await consumer.record_end_offsets(consumer)
-        consumer.sleep.coro.assert_called_once_with(
-            consumer._end_offset_monitor_interval)
-        consumer.highwaters.assert_called_once_with(*assignment)
-        assert consumer.app.monitor.tp_end_offsets == highwaters


### PR DESCRIPTION
## Description

Seems like the way I was looking at the highwater was inefficient. The highwater is available in every fetch request so looking at it on ever new message that comes in should be enough. The disadvantage here is that this wont track metrics if the consumer stalls for some reason and the lag keeps increasing. This will only give us insights into the lag while we are actually processing messages.

This is fine though as monitoring if the consumer is polling correctly should be added separately in the consumer by monitoring the poll method.

