### PR TITLE
Backward incompatible: *.send now requires keyword-only arguments only

### DIFF
--- a/faust/agents/agent.py
+++ b/faust/agents/agent.py
@@ -582,7 +582,7 @@ class Agent(AgentT, ServiceProxy):
                    *,
                    key: K = None,
                    partition: int = None) -> None:
-        await self.send(key, value, partition=partition)
+        await self.send(key=key, value=value, partition=partition)
 
     async def ask(self,
                   value: V = None,
@@ -613,7 +613,12 @@ class Agent(AgentT, ServiceProxy):
                          correlation_id: str = None,
                          force: bool = False) -> ReplyPromise:
         req = self._create_req(key, value, reply_to, correlation_id)
-        await self.channel.send(key, req, partition, force=force)
+        await self.channel.send(
+            key=key,
+            value=req,
+            partition=partition,
+            force=force,
+        )
         return ReplyPromise(req.reply_to, req.correlation_id)
 
     def _create_req(self,
@@ -632,13 +637,13 @@ class Agent(AgentT, ServiceProxy):
         )
 
     async def send(self,
+                   *,
                    key: K = None,
                    value: V = None,
                    partition: int = None,
                    key_serializer: CodecArg = None,
                    value_serializer: CodecArg = None,
                    callback: MessageSentCallback = None,
-                   *,
                    reply_to: ReplyToArg = None,
                    correlation_id: str = None,
                    force: bool = False) -> Awaitable[RecordMetadata]:
@@ -646,11 +651,11 @@ class Agent(AgentT, ServiceProxy):
         if reply_to:
             value = self._create_req(key, value, reply_to, correlation_id)
         return await self.channel.send(
-            key,
-            value,
-            partition,
-            key_serializer,
-            value_serializer,
+            key=key,
+            value=value,
+            partition=partition,
+            key_serializer=key_serializer,
+            value_serializer=value_serializer,
             force=force,
         )
 

--- a/faust/app/base.py
+++ b/faust/app/base.py
@@ -776,12 +776,12 @@ class App(AppT, ServiceProxy, ServiceCallbacks):
         else:
             chan = channel
         return await chan.send(
-            key,
-            value,
-            partition,
-            key_serializer,
-            value_serializer,
-            callback,
+            key=key,
+            value=value,
+            partition=partition,
+            key_serializer=key_serializer,
+            value_serializer=value_serializer,
+            callback=callback,
         )
 
     @stampede

--- a/faust/channels.py
+++ b/faust/channels.py
@@ -146,6 +146,7 @@ class Channel(ChannelT):
         raise NotImplementedError('Channels are unnamed topics')
 
     async def send(self,
+                   *,
                    key: K = None,
                    value: V = None,
                    partition: int = None,

--- a/faust/types/agents.py
+++ b/faust/types/agents.py
@@ -179,12 +179,12 @@ class AgentT(ServiceT):
 
     @abc.abstractmethod
     async def send(self,
+                   *,
                    key: K = None,
                    value: V = None,
                    partition: int = None,
                    key_serializer: CodecArg = None,
                    value_serializer: CodecArg = None,
-                   *,
                    reply_to: ReplyToArg = None,
                    correlation_id: str = None) -> Awaitable[RecordMetadata]:
         ...

--- a/faust/types/channels.py
+++ b/faust/types/channels.py
@@ -68,6 +68,7 @@ class ChannelT(AsyncIterator):
 
     @abc.abstractmethod
     async def send(self,
+                   *,
                    key: K = None,
                    value: V = None,
                    partition: int = None,


### PR DESCRIPTION
I keep making the mistake of doing:

    channel.send(x)

and expect that to send `x` as the value.

But the signature is `(key, value, ...)`, so it ends up being
`channel.send(key=x, value=None)`.

This is confusing to other users as well, most recently in post
on the faust-users mailing-list.

Fixing this will come in two parts:

1) Faust 1.1 (this change): Make them keyword-only arguments

    This will make it an error if the names of arguments are not
    specified.

    Code like this:

    ```py
    channel.send(key, value)
    ```
    Must be changed into:

    ```py
        channel.send(key=key, value=value)
    ```
2) Faust 1.2: We will change the signature to ``channel.send(value, key=key, ...)``

    At this stage all existing code will have changed to using
    keyword-only arguments.
