### PR TITLE
Change default key serializer to raw

### DIFF
--- a/docs/userguide/settings.rst
+++ b/docs/userguide/settings.rst
@@ -284,7 +284,7 @@ Serialization Settings
 ------------------
 
 :type: ``Union[str, Codec]``
-:default: ``"json"``
+:default: ``"raw"``
 
 Serializer used for keys by default when no serializer is specified, or a
 model is not being used.

--- a/faust/types/settings.py
+++ b/faust/types/settings.py
@@ -196,7 +196,7 @@ class Settings(abc.ABC):
     broker_check_crcs: bool = True
     id_format: str = '{id}-v{self.version}'
     origin: Optional[str] = None
-    key_serializer: CodecArg = 'json'
+    key_serializer: CodecArg = 'raw'
     value_serializer: CodecArg = 'json'
     reply_to: str
     reply_to_prefix: str = REPLY_TO_PREFIX

--- a/t/functional/test_app.py
+++ b/t/functional/test_app.py
@@ -50,7 +50,7 @@ class test_settings:
 
         assert not conf.autodiscover
         assert conf.origin is None
-        assert conf.key_serializer == 'json'
+        assert conf.key_serializer == 'raw'
         assert conf.value_serializer == 'json'
         assert conf.reply_to is not None
         assert not conf.reply_create_topic

--- a/t/unit/agents/test_agent.py
+++ b/t/unit/agents/test_agent.py
@@ -536,7 +536,8 @@ class test_Agent:
     async def test_cast(self, *, agent):
         agent.send = AsyncMock(name='send')
         await agent.cast('value', key='key', partition=303)
-        agent.send.assert_called_once_with('key', 'value', partition=303)
+        agent.send.assert_called_once_with(
+            key='key', value='value', partition=303)
 
     @pytest.mark.asyncio
     async def test_ask(self, *, agent):
@@ -587,7 +588,7 @@ class test_Agent:
         agent._create_req.assert_called_once_with(
             'key', 'value', 'reply_to', 'correlation_id')
         agent.channel.send.assert_called_once_with(
-            'key', agent._create_req(), 303, force=True)
+            key='key', value=agent._create_req(), partition=303, force=True)
 
         assert res.reply_to == agent._create_req().reply_to
         assert res.correlation_id == agent._create_req().correlation_id
@@ -632,11 +633,11 @@ class test_Agent:
         )
 
         agent.channel.send.assert_called_once_with(
-            b'key',
-            agent._create_req(),
-            303,
-            'raw',
-            'raw',
+            key=b'key',
+            value=agent._create_req(),
+            partition=303,
+            key_serializer='raw',
+            value_serializer='raw',
             force=True,
         )
 
@@ -667,11 +668,11 @@ class test_Agent:
         agent._create_req.assert_not_called()
 
         agent.channel.send.assert_called_once_with(
-            b'key',
-            b'value',
-            303,
-            'raw',
-            'raw',
+            key=b'key',
+            value=b'value',
+            partition=303,
+            key_serializer='raw',
+            value_serializer='raw',
             force=True,
         )
 

--- a/t/unit/app/test_base.py
+++ b/t/unit/app/test_base.py
@@ -64,11 +64,11 @@ async def test_send(
     expected_sender = app.producer.send_and_wait
     if key is not None:
         if isinstance(key, str):
-            # Default serializer is json, and str should be serialized
+            # Default serializer is raw, and str should be serialized
             # (note that a bytes key will be left alone.
-            key_serializer = 'json'
+            key_serializer = 'raw'
         if isinstance(key, ModelT):
-            expected_key = key.dumps(serializer='json')
+            expected_key = key.dumps(serializer='raw')
         elif key_serializer:
             expected_key = codecs.dumps(key_serializer, key)
         else:


### PR DESCRIPTION
## Description
This PR changed the default key serializer to raw. This is to avoid key decode error when consuming from Kafka topic without specifying key_serializer in `app.topics`. By default Kafka uses string serializer for all keys.

Also fixed broken unit tests.
