### PR TITLE
Do not install examples package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -121,7 +121,7 @@ setup(
     url=meta['homepage'],
     platforms=['any'],
     license='BSD',
-    packages=find_packages(exclude=['ez_setup', 't', 't.*']),
+    packages=find_packages(exclude=['examples', 'ez_setup', 't', 't.*']),
     # PEP-561: https://www.python.org/dev/peps/pep-0561/
     package_data={'faust': ['py.typed']},
     include_package_data=True,


### PR DESCRIPTION
Packaging Faust for Gentoo Linux gave a QA warning, because the `examples` packages was being installed along with the `faust` package when using the v1.0.30 tarball from PyPI.

This PR prevents the `examples` package from being installed by setuptools.

Removing `examples/__init__.py` would work, too, but some tests seem to rely on `examples` being a Python package.