### PR TITLE
[Web] Adds support for Flask-like "blueprints"

### DIFF
--- a/docs/reference/faust.web.blueprints.rst
+++ b/docs/reference/faust.web.blueprints.rst
@@ -1,0 +1,11 @@
+=====================================================
+ ``faust.web.blueprints``
+=====================================================
+
+.. contents::
+    :local:
+.. currentmodule:: faust.web.blueprints
+
+.. automodule:: faust.web.blueprints
+    :members:
+    :undoc-members:

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -200,6 +200,7 @@ Web
     faust.web.apps.router
     faust.web.apps.stats
     faust.web.base
+    faust.web.blueprints
     faust.web.drivers
     faust.web.drivers.aiohttp
     faust.web.site

--- a/faust/app/base.py
+++ b/faust/app/base.py
@@ -76,6 +76,7 @@ from faust.types.transports import (
 )
 from faust.types.tuples import MessageSentCallback, RecordMetadata, TP
 from faust.types.web import (
+    BlueprintT,
     HttpClientT,
     PageArg,
     RoutedViewGetHandler,
@@ -223,6 +224,8 @@ class App(AppT, ServiceProxy, ServiceCallbacks):
 
     _extra_services: List[ServiceT]
 
+    _blueprints: MutableMapping[str, BlueprintT]
+
     # See faust/app/_attached.py
     _attachments: Attachments
 
@@ -261,6 +264,8 @@ class App(AppT, ServiceProxy, ServiceCallbacks):
 
         # Any additional web server views added using @app.page decorator.
         self.pages = []
+        # currently used to add blueprint static paths
+        self._blueprints = {}
 
         # Any additional services added using the @app.service decorator.
         self._extra_services = []

--- a/faust/app/base.py
+++ b/faust/app/base.py
@@ -735,9 +735,10 @@ class App(AppT, ServiceProxy, ServiceCallbacks):
         return table.using_window(window) if window else table
 
     def page(self, path: str, *,
-             base: Type[View] = View) -> Callable[[PageArg], Type[Site]]:
+             base: Type[View] = View,
+             name: str = None) -> Callable[[PageArg], Type[Site]]:
         def _decorator(fun: PageArg) -> Type[Site]:
-            site = Site.from_handler(path, base=base)(fun)
+            site = Site.from_handler(path, base=base, name=name)(fun)
             self.pages.append(('', site))
             venusian.attach(site, category=SCAN_PAGE)
             return site

--- a/faust/types/app.py
+++ b/faust/types/app.py
@@ -206,7 +206,8 @@ class AppT(ServiceT):
 
     @abc.abstractmethod
     def page(self, path: str, *,
-             base: Type[View] = View) -> Callable[[PageArg], Type[Site]]:
+             base: Type[View] = View,
+             name: str = None) -> Callable[[PageArg], Type[Site]]:
         ...
 
     @abc.abstractmethod

--- a/faust/types/app.py
+++ b/faust/types/app.py
@@ -38,7 +38,7 @@ from .tables import CollectionT, TableManagerT, TableT
 from .topics import ChannelT, TopicT
 from .transports import ConductorT, ConsumerT, ProducerT, TransportT
 from .tuples import MessageSentCallback, RecordMetadata, TP
-from .web import HttpClientT, PageArg, RoutedViewGetHandler, Site, View, Web
+from .web import HttpClientT, PageArg, RoutedViewGetHandler, View, Web
 from .windows import WindowT
 
 if typing.TYPE_CHECKING:
@@ -93,7 +93,7 @@ class AppT(ServiceT):
 
     agents: AgentManagerT
     sensors: SensorDelegateT
-    pages: List[Tuple[str, Type[Site]]]
+    pages: List[Tuple[str, Type[View]]]
 
     fixups: MutableSequence[FixupT]
 
@@ -207,7 +207,7 @@ class AppT(ServiceT):
     @abc.abstractmethod
     def page(self, path: str, *,
              base: Type[View] = View,
-             name: str = None) -> Callable[[PageArg], Type[Site]]:
+             name: str = None) -> Callable[[PageArg], Type[View]]:
         ...
 
     @abc.abstractmethod

--- a/faust/types/web.py
+++ b/faust/types/web.py
@@ -1,12 +1,16 @@
+import abc
 import typing
-from typing import Awaitable, Callable, Type, Union
+from pathlib import Path
+from typing import Awaitable, Callable, Optional, Type, Union
 
 from aiohttp.client import ClientSession
 
 if typing.TYPE_CHECKING:
+    from faust.types.app import AppT
     from faust.web.base import Request, Response, Web
     from faust.web.views import Site, View
 else:
+    class AppT: ...           # noqa
     class Request: ...        # noqa
     class Response: ...       # noqa
     class Web: ...            # noqa
@@ -23,12 +27,40 @@ __all__ = [
     'PageArg',
     'HttpClientT',
     'Web',
+    'BlueprintT',
 ]
 
 ViewGetHandler = Callable[[View, Request], Awaitable[Response]]
 RoutedViewGetHandler = Callable[[ViewGetHandler], ViewGetHandler]
 PageArg = Union[Type[View], ViewGetHandler]
+RouteDecoratorRet = Callable[[PageArg], PageArg]
 
 
 class HttpClientT(ClientSession):
     ...
+
+
+class BlueprintT(abc.ABC):
+    name: str
+    url_prefix: Optional[str]
+
+    @abc.abstractmethod
+    def route(self,
+              uri: str,
+              *,
+              name: Optional[str] = None,
+              base: Type[View] = View) -> RouteDecoratorRet:
+        ...
+
+    @abc.abstractmethod
+    def static(self,
+               uri: str,
+               file_or_directory: Union[str, Path],
+               *,
+               name: Optional[str] = None) -> None:
+        ...
+
+    def register(self, app: AppT,
+                 *,
+                 url_prefix: Optional[str] = None) -> None:
+        ...

--- a/faust/types/web.py
+++ b/faust/types/web.py
@@ -8,19 +8,17 @@ from aiohttp.client import ClientSession
 if typing.TYPE_CHECKING:
     from faust.types.app import AppT
     from faust.web.base import Request, Response, Web
-    from faust.web.views import Site, View
+    from faust.web.views import View
 else:
     class AppT: ...           # noqa
     class Request: ...        # noqa
     class Response: ...       # noqa
     class Web: ...            # noqa
-    class Site: ...           # noqa
     class View: ...           # noqa
 
 __all__ = [
     'Request',
     'Response',
-    'Site',
     'View',
     'ViewGetHandler',
     'RoutedViewGetHandler',

--- a/faust/web/__init__.py
+++ b/faust/web/__init__.py
@@ -1,10 +1,12 @@
 from .base import Request, Response, Web
+from .blueprints import Blueprint
 from .views import Site, View
 
 __all__ = [
     'Request',
     'Response',
     'Web',
+    'Blueprint',
     'View',
     'Site',
 ]

--- a/faust/web/__init__.py
+++ b/faust/web/__init__.py
@@ -1,6 +1,6 @@
 from .base import Request, Response, Web
 from .blueprints import Blueprint
-from .views import Site, View
+from .views import View
 
 __all__ = [
     'Request',
@@ -8,5 +8,4 @@ __all__ = [
     'Web',
     'Blueprint',
     'View',
-    'Site',
 ]

--- a/faust/web/apps/graph.py
+++ b/faust/web/apps/graph.py
@@ -2,9 +2,12 @@
 import io
 from faust import web
 
-__all__ = ['Graph', 'Site']
+__all__ = ['Graph', 'blueprint']
+
+blueprint = web.Blueprint('graph')
 
 
+@blueprint.route('/', name='detail')
 class Graph(web.View):
     """Render image from graph of running services."""
 
@@ -19,11 +22,3 @@ class Graph(web.View):
         beacon.as_graph().to_dot(o)
         graph, = pydot.graph_from_dot_data(o.getvalue())
         return self.bytes(graph.create_png(), content_type='image/png')
-
-
-class Site(web.Site):
-    """Graph views."""
-
-    views = {
-        '/': Graph,
-    }

--- a/faust/web/apps/router.py
+++ b/faust/web/apps/router.py
@@ -1,10 +1,13 @@
 """HTTP endpoint showing partition routing destinations."""
 from faust import web
 
-__all__ = ['TablesMetadata', 'TableMetadata', 'KeyMetadata']
+__all__ = ['TableList', 'TableDetail', 'TableKeyDetail', 'blueprint']
+
+blueprint = web.Blueprint('router')
 
 
-class TablesMetadata(web.View):
+@blueprint.route('/', name='list')
+class TableList(web.View):
     """List routes for all tables."""
 
     async def get(self, request: web.Request) -> web.Response:
@@ -12,7 +15,8 @@ class TablesMetadata(web.View):
         return self.json(router.tables_metadata())
 
 
-class TableMetadata(web.View):
+@blueprint.route('/{name}/', name='detail')
+class TableDetail(web.View):
     """List route for specific table."""
 
     async def get(self, request: web.Request) -> web.Response:
@@ -22,7 +26,8 @@ class TableMetadata(web.View):
         return self.json(router.table_metadata(table_name))
 
 
-class KeyMetadata(web.View):
+@blueprint.route('/{name}/{key}/', name='key-detail')
+class TableKeyDetail(web.View):
     """List information about key."""
 
     async def get(self, request: web.Request) -> web.Response:
@@ -30,13 +35,3 @@ class KeyMetadata(web.View):
         key = request.match_info['key']
         router = self.app.router
         return self.json(str(router.key_store(table_name, key)))
-
-
-class Site(web.Site):
-    """Router views."""
-
-    views = {
-        '/': TablesMetadata,
-        '/{name}/': TableMetadata,
-        '/{name}/{key}/': KeyMetadata,
-    }

--- a/faust/web/apps/router.py
+++ b/faust/web/apps/router.py
@@ -19,19 +19,18 @@ class TableList(web.View):
 class TableDetail(web.View):
     """List route for specific table."""
 
-    async def get(self, request: web.Request) -> web.Response:
-        # FIXME request.match_info is an attribute of aiohttp.Request
-        table_name = request.match_info['name']
+    async def get(self, request: web.Request, name: str) -> web.Response:
         router = self.app.router
-        return self.json(router.table_metadata(table_name))
+        return self.json(router.table_metadata(name))
 
 
 @blueprint.route('/{name}/{key}/', name='key-detail')
 class TableKeyDetail(web.View):
     """List information about key."""
 
-    async def get(self, request: web.Request) -> web.Response:
-        table_name = request.match_info['name']
-        key = request.match_info['key']
+    async def get(self,
+                  request: web.Request,
+                  name: str,
+                  key: str) -> web.Response:
         router = self.app.router
-        return self.json(str(router.key_store(table_name, key)))
+        return self.json(str(router.key_store(name, key)))

--- a/faust/web/apps/stats.py
+++ b/faust/web/apps/stats.py
@@ -4,11 +4,15 @@ from typing import List, MutableMapping, Set
 from faust import web
 from faust.types.tuples import TP
 
-__all__ = ['Assignment', 'Stats', 'Site']
+__all__ = ['Assignment', 'Stats', 'blueprint']
 
 TPMap = MutableMapping[str, List[int]]
 
 
+blueprint = web.Blueprint('monitor')
+
+
+@blueprint.route('/', name='index')
 class Stats(web.View):
     """Monitor statistics."""
 
@@ -18,6 +22,7 @@ class Stats(web.View):
              for i, s in enumerate(self.app.sensors)})
 
 
+@blueprint.route('/assignment/', name='assignment')
 class Assignment(web.View):
     """Cluster assignment information."""
 
@@ -34,12 +39,3 @@ class Assignment(web.View):
             'actives': self._topic_grouped(assignor.assigned_actives()),
             'standbys': self._topic_grouped(assignor.assigned_standbys()),
         })
-
-
-class Site(web.Site):
-    """Statistics views."""
-
-    views = {
-        '/': Stats,
-        '/assignment/': Assignment,
-    }

--- a/faust/web/apps/tables.py
+++ b/faust/web/apps/tables.py
@@ -60,9 +60,7 @@ class TableList(TableView):
 class TableDetail(TableView):
     """Get details for table by name."""
 
-    async def get(self, request: web.Request) -> web.Response:
-        # FIXME request.match_info is an attribute of aiohttp.Request
-        name = request.match_info['name']
+    async def get(self, request: web.Request, name: str) -> web.Response:
         table, error = self.get_table(name)
         if error is not None:
             return error
@@ -76,9 +74,10 @@ class TableKeyDetail(TableView):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
-    async def get(self, request: web.Request) -> web.Response:
-        name = request.match_info['name']
-        key = request.match_info['key']
+    async def get(self,
+                  request: web.Request,
+                  name: str,
+                  key: str) -> web.Response:
         router = self.app.router
         try:
             return await router.route_req(name, key, self.web, request)

--- a/faust/web/apps/tables.py
+++ b/faust/web/apps/tables.py
@@ -5,7 +5,16 @@ from faust.app.router import SameNode
 from faust.models import Record
 from faust.types import K, TableT
 
-__all__ = ['TableView', 'TableList', 'TableDetail', 'TableKeyDetail']
+__all__ = [
+    'TableView',
+    'TableList',
+    'TableDetail',
+    'TableKeyDetail',
+    'blueprint',
+]
+
+
+blueprint = web.Blueprint('tables')
 
 
 class TableInfo(Record, serializer='json', namespace='@TableInfo'):
@@ -38,6 +47,7 @@ class TableView(web.View):
                 'key not found', table=table.name, key=key)
 
 
+@blueprint.route('/', name='list')
 class TableList(TableView):
     """List available table names."""
 
@@ -46,6 +56,7 @@ class TableList(TableView):
             [self.table_json(table) for table in self.app.tables.values()])
 
 
+@blueprint.route('/{name}/', name='detail')
 class TableDetail(TableView):
     """Get details for table by name."""
 
@@ -58,6 +69,7 @@ class TableDetail(TableView):
         return self.json(self.table_json(table))
 
 
+@blueprint.route('/{name}/{key}/', name='key-detail')
 class TableKeyDetail(TableView):
     """List information about key."""
 
@@ -78,13 +90,3 @@ class TableKeyDetail(TableView):
             if error is not None:
                 return error
             return self.json(value)
-
-
-class Site(web.Site):
-    """Router views."""
-
-    views = {
-        '/': TableList,
-        '/{name}/': TableDetail,
-        '/{name}/{key}/': TableKeyDetail,
-    }

--- a/faust/web/base.py
+++ b/faust/web/base.py
@@ -62,8 +62,9 @@ class Web(Service):
             path = self.reverse_names[view_name]
         except KeyError:
             raise KeyError(f'No view with name {view_name!r} found')
-        return path.format(**{
-            k: self._quote_for_url(str(v)) for k, v in kwargs.items()})
+        else:
+            return path.format(**{
+                k: self._quote_for_url(str(v)) for k, v in kwargs.items()})
 
     def _quote_for_url(self, value: str) -> str:
         return quote(value, safe='')  # disable '/' being safe by default

--- a/faust/web/base.py
+++ b/faust/web/base.py
@@ -1,6 +1,7 @@
 """Base interface for Web server and views."""
 from pathlib import Path
 from typing import Any, Callable, MutableMapping, Type, Union
+from urllib.parse import quote
 from mode import Service
 from yarl import URL
 from faust.cli._env import WEB_BIND, WEB_PORT
@@ -49,6 +50,23 @@ class Web(Service):
         self.views[path] = view
         self.reverse_names[view.view_name] = path
         return view
+
+    def url_for(self, view_name: str, **kwargs: Any) -> str:
+        """Get URL by view name
+
+        If the provided view name has associated URL parameters,
+        those need to be passed in as kwargs, or a :exc:`TypeError`
+        will be raised.
+        """
+        try:
+            path = self.reverse_names[view_name]
+        except KeyError:
+            raise KeyError(f'No view with name {view_name!r} found')
+        return path.format(**{
+            k: self._quote_for_url(str(v)) for k, v in kwargs.items()})
+
+    def _quote_for_url(self, value: str) -> str:
+        return quote(value, safe='')  # disable '/' being safe by default
 
     def text(self, value: str, *, content_type: str = None,
              status: int = 200) -> Response:

--- a/faust/web/blueprints.py
+++ b/faust/web/blueprints.py
@@ -29,6 +29,7 @@ class FutureStaticRoute(NamedTuple):
 class Blueprint(BlueprintT):
     routes: List[FutureRoute]
     static_routes: List[FutureStaticRoute]
+    view_name_separator: str = ':'
 
     def __init__(self,
                  name: str,
@@ -92,8 +93,13 @@ class Blueprint(BlueprintT):
                      url_prefix: Optional[str]) -> None:
         uri = url_prefix + route.uri if url_prefix else route.uri
 
-        app.page(path=uri[1:] if uri.startswith('//') else uri,
-                 name=route.name)(route.handler)
+        app.page(
+            path=uri[1:] if uri.startswith('//') else uri,
+            name=self._view_name(route.name),
+        )(route.handler)
+
+    def _view_name(self, name: str) -> str:
+        return self.view_name_separator.join([self.name, name])
 
     def init_webserver(self, web: Web) -> None:
         for route in self.static_routes:

--- a/faust/web/blueprints.py
+++ b/faust/web/blueprints.py
@@ -1,0 +1,86 @@
+from pathlib import Path
+from typing import List, NamedTuple, Optional, Type, Union
+
+from faust.types import AppT
+from faust.types.web import BlueprintT, PageArg, RouteDecoratorRet, View
+
+__all__ = ['Blueprint']
+
+
+class FutureRoute(NamedTuple):
+    uri: str
+    name: Optional[str]
+    handler: PageArg
+    base: Type[View]
+
+
+class FutureStaticRoute(NamedTuple):
+    uri: str
+    file_or_directory: Path
+    name: str
+
+
+class Blueprint(BlueprintT):
+    routes: List[FutureRoute]
+    static_routes: List[FutureStaticRoute]
+
+    def __init__(self,
+                 name: str,
+                 *,
+                 url_prefix: Optional[str] = None) -> None:
+        self.name = name
+        self.url_prefix = url_prefix
+
+        self.routes = []
+        self.static_routes = []
+
+    def route(self,
+              uri: str,
+              *,
+              name: Optional[str] = None,
+              base: Type[View] = View) -> RouteDecoratorRet:
+        def _inner(handler: PageArg) -> PageArg:
+            route = FutureRoute(uri, name, handler, base)
+            self.routes.append(route)
+            return handler
+        return _inner
+
+    def static(self,
+               uri: str,
+               file_or_directory: Union[str, Path],
+               *,
+               name: Optional[str] = None) -> None:
+        _name: str = name or 'static'
+        if not _name.startswith(self.name + '.'):
+            _name = f'{self.name}.{name}'
+        fut = FutureStaticRoute(uri, Path(file_or_directory), _name)
+        self.static_routes.append(fut)
+
+    def register(self, app: AppT,
+                 *,
+                 url_prefix: Optional[str] = None) -> None:
+        url_prefix = url_prefix or self.url_prefix
+
+        # Routes
+        for route in self.routes:
+            self._apply_route(app, route, url_prefix)
+
+        # Static Routes
+        for static_route in self.static_routes:
+            self._apply_static_route(app, static_route, url_prefix)
+
+    def _apply_route(self,
+                     app: AppT,
+                     route: FutureRoute,
+                     url_prefix: Optional[str]) -> None:
+        uri = url_prefix + route.uri if url_prefix else route.uri
+
+        app.page(path=uri[1:] if uri.startswith('//') else uri,
+                 name=route.name)(route.handler)
+
+    def _apply_static_route(self,
+                            app: AppT,
+                            route: FutureStaticRoute,
+                            url_prefix: Optional[str]) -> None:
+        uri = url_prefix + route.uri if url_prefix else route.uri
+        app.static(uri, route.file_or_directory, name=route.name)

--- a/faust/web/blueprints.py
+++ b/faust/web/blueprints.py
@@ -42,10 +42,24 @@ class Blueprint(BlueprintT):
         self.static_routes = []
 
     def clone(self, url_prefix: Optional[str] = None) -> BlueprintT:
+        # Clone is only used for keeping track of static paths.
+        # We have app.page(), but no app.static() so solved this
+        # by keeping a mapping of the blueprint added to each app
+        # (in app._blueprints).
+        #
+        # blueprint.register(app, uri_prefix) adds itself to this mapping
+        # by creating a copy of the blueprint with that url_prefix set.
+
         if url_prefix is None:
             url_prefix = self.url_prefix
         bp = type(self)(name=self.name, url_prefix=url_prefix)
-        bp.routes = self.routes  # XXX Do not modify!!!
+
+        # Note: The clone will not copy the list of routes, so any changes
+        # to these in the clone will be reflected in the original.
+        # (that is @app._blueprint['name'].route() will be added to all apps
+        #  using that blueprint, pretty sure nobody would do this so
+        #  it's safe).
+        bp.routes = self.routes
         bp.static_routes = self.static_routes
         return bp
 

--- a/faust/web/site.py
+++ b/faust/web/site.py
@@ -59,6 +59,8 @@ class Website(Service):
             bind=self.bind,
             **kwargs)
         self.app.on_webserver_init(self.web)
+        for blueprint in self.app._blueprints.values():
+            blueprint.init_webserver(self.web)
 
     def init_pages(self,
                    extra_pages: Sequence[Tuple[str, Type[Site]]]) -> None:

--- a/faust/web/site.py
+++ b/faust/web/site.py
@@ -47,6 +47,7 @@ class Website(Service):
         self.bind = bind or 'localhost'
         self.init_driver(driver, **kwargs)
         self.init_pages(extra_pages or [])
+        self.init_webserver()
         self.add_dependency(self.web)
 
     def init_driver(self, driver: Union[Type[Web], str],
@@ -57,9 +58,6 @@ class Website(Service):
             port=self.port,
             bind=self.bind,
             **kwargs)
-        self.app.on_webserver_init(self.web)
-        for blueprint in self.app._blueprints.values():
-            blueprint.init_webserver(self.web)
 
     def init_pages(self,
                    extra_pages: Sequence[Tuple[str, Type[View]]]) -> None:
@@ -68,3 +66,10 @@ class Website(Service):
             blueprint.register(app, url_prefix=prefix)
         for prefix, page in list(app.pages) + list(extra_pages or []):
             self.web.add_view(page, prefix=prefix)
+
+    def init_webserver(self) -> None:
+        self.app.on_webserver_init(self.web)
+        for _, blueprint in self.blueprints:
+            blueprint.init_webserver(self.web)
+        for blueprint in self.app._blueprints.values():
+            blueprint.init_webserver(self.web)

--- a/faust/web/site.py
+++ b/faust/web/site.py
@@ -4,6 +4,7 @@ from typing import Any, Sequence, Tuple, Type, Union
 from mode import Service
 
 from faust.types import AppT
+from faust.types.web import BlueprintT
 
 from . import drivers
 from .apps import graph
@@ -26,11 +27,11 @@ class Website(Service):
     port: int
     bind: str
 
-    pages: Sequence[Tuple[str, Type[Site]]] = [
-        ('/graph', graph.Site),
-        ('', stats.Site),
-        ('/router', router.Site),
-        ('/table', tables.Site),
+    blueprints: Sequence[Tuple[str, BlueprintT]] = [
+        ('/graph', graph.blueprint),
+        ('', stats.blueprint),
+        ('/router', router.blueprint),
+        ('/table', tables.blueprint),
     ]
 
     def __init__(self,
@@ -62,6 +63,7 @@ class Website(Service):
     def init_pages(self,
                    extra_pages: Sequence[Tuple[str, Type[Site]]]) -> None:
         app = self.app
-        pages = list(self.pages) + list(app.pages) + list(extra_pages or [])
-        for prefix, page in pages:
+        for prefix, blueprint in self.blueprints:
+            blueprint.register(app, url_prefix=prefix)
+        for prefix, page in list(app.pages) + list(extra_pages or []):
             page(app).enable(self.web, prefix=prefix)

--- a/faust/web/site.py
+++ b/faust/web/site.py
@@ -4,7 +4,7 @@ from typing import Any, Sequence, Tuple, Type, Union
 from mode import Service
 
 from faust.types import AppT
-from faust.types.web import BlueprintT
+from faust.types.web import BlueprintT, View
 
 from . import drivers
 from .apps import graph
@@ -12,7 +12,6 @@ from .apps import router
 from .apps import stats
 from .apps import tables
 from .base import Web
-from .views import Site
 
 __all__ = ['Website']
 
@@ -40,7 +39,7 @@ class Website(Service):
                  port: int = None,
                  bind: str = None,
                  driver: Union[Type[Web], str] = DEFAULT_DRIVER,
-                 extra_pages: Sequence[Tuple[str, Type[Site]]] = None,
+                 extra_pages: Sequence[Tuple[str, Type[View]]] = None,
                  **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.app = app
@@ -63,9 +62,9 @@ class Website(Service):
             blueprint.init_webserver(self.web)
 
     def init_pages(self,
-                   extra_pages: Sequence[Tuple[str, Type[Site]]]) -> None:
+                   extra_pages: Sequence[Tuple[str, Type[View]]]) -> None:
         app = self.app
         for prefix, blueprint in self.blueprints:
             blueprint.register(app, url_prefix=prefix)
         for prefix, page in list(app.pages) + list(extra_pages or []):
-            page(app).enable(self.web, prefix=prefix)
+            self.web.add_view(page, prefix=prefix)

--- a/faust/web/views.py
+++ b/faust/web/views.py
@@ -103,6 +103,7 @@ class Site:
     """Collection of HTTP endpoints (views)."""
 
     views: Mapping[str, Type[View]]
+    names: Mapping[str, str]
 
     def __init__(self, app: AppT) -> None:
         self.app = app
@@ -120,7 +121,8 @@ class Site:
 
     @classmethod
     def from_handler(cls, path: str, *,
-                     base: Type[View] = None) -> CommandDecorator:
+                     base: Type[View] = None,
+                     name: str = None) -> CommandDecorator:
         view_base: Type[View] = base if base is not None else View
 
         def _decorator(fun: PageArg) -> Type[Site]:
@@ -133,9 +135,14 @@ class Site:
             if view is None:
                 view = view_base.from_handler(cast(ViewGetHandler, fun))
 
+            _name = name or fun.__name__
+
             return type('Site', (cls,), {
                 'views': {
                     path: view,
+                },
+                'names': {
+                    _name: path,
                 },
                 '__module__': fun.__module__,
             })

--- a/faust/web/views.py
+++ b/faust/web/views.py
@@ -9,6 +9,7 @@ from typing import (
     Optional,
     Type,
     cast,
+    no_type_check,
 )
 
 from faust.types import AppT
@@ -54,20 +55,30 @@ class View:
 
     async def dispatch(self, request: Any) -> Any:
         method = request.method.lower()
-        return await self.methods[method](cast(Request, request))
+        kwargs = request.match_info or {}  # XXX Aiohttp specific
 
+        # we cast here since some subclasses take extra parameters
+        # from the URL route (match_info).
+        method = cast(Callable[..., Awaitable[Response]], self.methods[method])
+        return await method(cast(Request, request), **kwargs)
+
+    @no_type_check  # subclasses change signature based on route match_info
     async def get(self, request: Request) -> Any:
         ...
 
+    @no_type_check  # subclasses change signature based on route match_info
     async def post(self, request: Request) -> Any:
         ...
 
+    @no_type_check  # subclasses change signature based on route match_info
     async def put(self, request: Request) -> Any:
         ...
 
+    @no_type_check  # subclasses change signature based on route match_info
     async def patch(self, request: Request) -> Any:
         ...
 
+    @no_type_check  # subclasses change signature based on route match_info
     async def delete(self, request: Request) -> Any:
         ...
 

--- a/t/unit/web/test_views.py
+++ b/t/unit/web/test_views.py
@@ -45,6 +45,7 @@ class test_View:
     async def test_dispatch(self, method, *, view):
         request = Mock(name='request', autospec=Request)
         request.method = method
+        request.match_info = {}
         handler = AsyncMock(name=method)
         view.methods[method.lower()] = handler
         assert await view(request) is handler.coro()

--- a/t/unit/web/test_views.py
+++ b/t/unit/web/test_views.py
@@ -1,7 +1,6 @@
 import pytest
-from mode.utils.mocks import AsyncMock, Mock, call
-from faust.web.base import Request, Web
-from faust.web.views import Site, View
+from mode.utils.mocks import AsyncMock, Mock
+from faust.web import Request, View, Web
 
 
 @View.from_handler
@@ -127,43 +126,3 @@ class test_View:
         web.json.assert_called_once_with(
             {'error': 'Not Found', 'arg': 'bharg'}, status=404)
         assert response is web.json()
-
-
-class test_Site:
-
-    @Site.from_handler('/foo')
-    def fun_view(self, request):
-        return self, request
-
-    @Site.from_handler('/bar')
-    class ViewCls(View):
-
-        async def get(self, request):
-            return self, request
-
-    @pytest.fixture()
-    def fun_site(self, app):
-        return self.fun_view(app)
-
-    @pytest.fixture()
-    def cls_site(self, app):
-        return self.ViewCls(app)
-
-    def test_constructor(self, cls_site, fun_site, app):
-        assert cls_site.app is app
-        assert fun_site.app is app
-
-    def test_enable(self, cls_site):
-        web = Mock(name='web', autospec=Web)
-        view = next(iter(cls_site.views.values()))
-        assert view
-        views = cls_site.enable(web, prefix='/xxx')
-        web.route.assert_has_calls([
-            call('/xxx/bar', views[0]),
-        ])
-
-    def test_from_handler__not_a_view(self):
-        with pytest.raises(TypeError):
-            class X:
-                pass
-            Site.from_handler('/x')(X)


### PR DESCRIPTION
Blueprint is basically just a description of a reusable app
that you can add to your web application.

Blueprints are commonly used in most Flask-like web frameworks,
but Flask blueprints are not compatible with e.g. Sanic blueprints.

The Faust blueprint is not directly compatible with any of them,
but that should be fine.

To define a blueprint:

```py

    from faust import web

    blueprint = web.Blueprint('user')

    @blueprint.route('/', name='list')
    class UserListView(web.View):

        async def get(self, request: web.Request) -> web.Response:
            return self.json({'hello': 'world'})

    @blueprint.route('/{username}/', name='detail')
    class UserDetailView(web.View):

        async def get(self, request: web.Request) -> web.Response:
            name = request.match_info['username']
            return self.json({'hello': name})

        async def post(self, request: web.Request) -> web.Response:
            ...

        async def delete(self, request: web.Request) -> web.Response:
            ...

```

Then to add the blueprint to a Faust app you register it:

```py
    blueprint.register(app, url_prefix='/users/')
```

NOTE:

You can also create views from functions (in this case it will only
support GET):

```py
@blueprint.route('/', name='index')
async def hello(self, request):
    return self.text('Hello world')
```

.
