### PR TITLE
[topics] Add allow_empty flag to handle topics with empty messages

### DIFF
--- a/faust/app/base.py
+++ b/faust/app/base.py
@@ -457,6 +457,7 @@ class App(AppT, ServiceProxy, ServiceCallbacks):
               internal: bool = False,
               config: Mapping[str, Any] = None,
               maxsize: int = None,
+              allow_empty: bool = False,
               loop: asyncio.AbstractEventLoop = None) -> TopicT:
         """Create topic description.
 
@@ -485,6 +486,7 @@ class App(AppT, ServiceProxy, ServiceCallbacks):
             acks=acks,
             internal=internal,
             config=config,
+            allow_empty=allow_empty,
             loop=loop,
         )
 

--- a/faust/tables/base.py
+++ b/faust/tables/base.py
@@ -330,6 +330,7 @@ class Collection(Service, CollectionT):
             # use large buffer size as we do not commit attached messages
             # when reading changelog streams.
             maxsize=131_072,
+            allow_empty=True,
         )
 
     def __copy__(self) -> Any:

--- a/faust/types/app.py
+++ b/faust/types/app.py
@@ -154,6 +154,7 @@ class AppT(ServiceT):
               internal: bool = False,
               config: Mapping[str, Any] = None,
               maxsize: int = None,
+              allow_empty: bool = False,
               loop: asyncio.AbstractEventLoop = None) -> TopicT:
         ...
 

--- a/faust/types/topics.py
+++ b/faust/types/topics.py
@@ -78,6 +78,7 @@ class TopicT(ChannelT):
                  maxsize: int = None,
                  root: ChannelT = None,
                  active_partitions: Set[TP] = None,
+                 allow_empty: bool = False,
                  loop: asyncio.AbstractEventLoop = None) -> None:
         ...
 

--- a/requirements/typecheck.txt
+++ b/requirements/typecheck.txt
@@ -1,1 +1,2 @@
 mypy~=0.610
+mypy-extensions~=0.4.1


### PR DESCRIPTION
## Description

Currently changelogs crashes when the kafka message type is `None`. This is because the `TopicConductor` tries to `decode` the message received from kafka which is empty. 

We add a functionality to set `allow_empty` for a topic so that it can allow reading empty messages. This can be problematic if used without knowing it because one would have to differentiate between and empty message received from kafka and a message that decodes to the value `None`. However we should be fine in the case of the changelog recovery as it uses the `event.message.value` to identify deletes.

This should fix #175 