### PR TITLE
Rebalances

### DIFF
--- a/examples/word_count.py
+++ b/examples/word_count.py
@@ -57,5 +57,10 @@ async def sender():
     ))
 
 
+@app.on_worker_init.connect
+def foo(sender, **kwargs):
+    print('ON WORKER INIT')
+
+
 if __name__ == '__main__':
     app.main()

--- a/faust/app/base.py
+++ b/faust/app/base.py
@@ -243,6 +243,9 @@ class App(AppT, ServiceProxy, ServiceCallbacks):
 
     _on_revoked_timeout = None
 
+    #: Current assignment
+    _assignment: Optional[Set[TP]] = None
+
     def __init__(self,
                  id: str,
                  *,
@@ -900,15 +903,13 @@ class App(AppT, ServiceProxy, ServiceCallbacks):
         """
         if self.should_stop:
             return self._on_rebalance_when_stopped()
-        session_timeout = self.conf.broker_session_timeout
+        session_timeout = self.conf.broker_session_timeout * 0.95
         with flight_recorder(self.log, timeout=session_timeout) as on_timeout:
             self._on_revoked_timeout = on_timeout
             try:
                 self.log.dev('ON PARTITIONS REVOKED')
                 on_timeout.info('fetcher.stop()')
                 await self._stop_fetcher()
-                on_timeout.info('tables.stop_standbys()')
-                await self.tables._stop_standbys()
                 assignment = self.consumer.assignment()
                 if assignment:
                     on_timeout.info('flow_control.suspend()')
@@ -931,19 +932,13 @@ class App(AppT, ServiceProxy, ServiceCallbacks):
                     if self.conf.stream_wait_empty:
                         on_timeout.info('consumer.wait_empty()')
                         await self.consumer.wait_empty()
-                    on_timeout.info('agents.on_partitions_revoked')
-                    await self.agents.on_partitions_revoked(revoked)
                 else:
                     self.log.dev('ON P. REVOKED NOT COMMITTING: NO ASSIGNMENT')
-                on_timeout.info('topics.on_partitions_revoked()')
-                await self.topics.on_partitions_revoked(revoked)
-                on_timeout.info('tables.on_partitions_revoked()')
-                await self.tables.on_partitions_revoked(revoked)
                 on_timeout.info('+send signal: on_partitions_revoked')
                 await self.on_partitions_revoked.send(revoked)
                 on_timeout.info('-send signal: on_partitions_revoked')
             except Exception as exc:
-                on_timeout.info('on partitions assigned crashed: %r', exc)
+                on_timeout.info('on partitions revoked crashed: %r', exc)
                 await self.crash(exc)
             finally:
                 self._on_revoked_timeout = None
@@ -968,12 +963,28 @@ class App(AppT, ServiceProxy, ServiceCallbacks):
         """
         if self.should_stop:
             return self._on_rebalance_when_stopped()
-        session_timeout = self.conf.broker_session_timeout
+        # shave some time off so we timeout before the broker
+        # (Kafka does not send error, it just logs)
+        session_timeout = self.conf.broker_session_timeout * 0.95
         self.unassigned = not assigned
+
+        revoked: Set[TP]
+        newly_assigned: Set[TP]
+        if self._assignment is not None:
+            revoked = self._assignment - assigned
+            newly_assigned = assigned - self._assignment
+        else:
+            revoked = set()
+            newly_assigned = set()  # noqa XXX unused
         with flight_recorder(self.log, timeout=session_timeout) as on_timeout:
+            self._on_revoked_timeout = on_timeout
             try:
                 on_timeout.info('fetcher.stop()')
                 await self._stop_fetcher()
+                on_timeout.info('tables.stop_standbys()')
+                await self.tables._stop_standbys()
+                on_timeout.info('agents.on_partitions_revoked()')
+                await self.agents.on_partitions_revoked(revoked)
                 on_timeout.info('agents.on_partitions_assigned()')
                 await self.agents.on_partitions_assigned(assigned)
                 # Wait for transport.Conductor to finish
@@ -982,8 +993,12 @@ class App(AppT, ServiceProxy, ServiceCallbacks):
                 await self.topics.wait_for_subscriptions()
                 on_timeout.info('consumer.pause_partitions()')
                 await self.consumer.pause_partitions(assigned)
+                on_timeout.info('topics.on_partitions_revoked')
+                await self.agents.on_partitions_revoked(revoked)
                 on_timeout.info('topics.on_partitions_assigned()')
                 await self.topics.on_partitions_assigned(assigned)
+                on_timeout.info('tables.on_partitions_revoked()')
+                await self.tables.on_partitions_revoked(revoked)
                 on_timeout.info('tables.on_partitions_assigned()')
                 await self.tables.on_partitions_assigned(assigned)
                 on_timeout.info('+send signal: on_partitions_assigned')
@@ -991,6 +1006,7 @@ class App(AppT, ServiceProxy, ServiceCallbacks):
                 on_timeout.info('-send signal: on_partitions_assigned')
                 on_timeout.info('flow_control.resume()')
                 self.flow_control.resume()
+                self._assignment = assigned
             except Exception as exc:
                 on_timeout.info('on partitions assigned crashed: %r', exc)
                 await self.crash(exc)

--- a/faust/types/settings.py
+++ b/faust/types/settings.py
@@ -152,7 +152,7 @@ BROKER_COMMIT_EVERY = 10_000
 BROKER_COMMIT_INTERVAL = 2.8
 
 #: Kafka consumer session timeout (``session_timeout_ms``).
-BROKER_SESSION_TIMEOUT = 30.0
+BROKER_SESSION_TIMEOUT = 60.0
 
 #: Kafka consumer heartbeat (``heartbeat_interval_ms``).
 BROKER_HEARTBEAT_INTERVAL = 3.0


### PR DESCRIPTION
    Rebalancing experiment

    - Do as little as possible in on_partition_revoked

    - TODO: Only start standbys for newly assigned partitions
    - TODO: Only stop agents/topics/standbys for actually revoked partitions
    - TODO: Start table recovery for newly assigned partitions
    - TODO: Stop table recovery for actually revoked partitions.