### PR TITLE
Use concurrency param in concurrency example

### DIFF
--- a/docs/userguide/agents.rst
+++ b/docs/userguide/agents.rst
@@ -425,9 +425,9 @@ then store that in a database somewhere (yeah, pretty contrived):
         url: str
         date_published: datetime
 
-    news_topic = app.topic('news')
+    news_topic = app.topic('news', value_type=Article)
 
-    @app.agent()
+    @app.agent(news_topic, concurrency=10)
     async def imports_news(articles):
         async for article in articles:
             response = await aiohttp.ClientSession().get(article.url)


### PR DESCRIPTION
I was reading through the [docs (using concurrency within an agent)](https://faust.readthedocs.io/en/latest/userguide/agents.html#concurrency) and I noticed that the example didn't use the `concurrency` parameter, which was misleading. 

In this PR: 
* I'm improving the docs to use the `concurrency` parameter in the code example. 
* I'm modifying the `flake8` dependency so that it doesn't pull its latest version