### PR TITLE
Use current_event when calling current with no event

### DIFF
--- a/examples/windowing/tumbling_current.py
+++ b/examples/windowing/tumbling_current.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+
+# In this exapmple we have a function `publish_every_2secs` publishing a
+# message every 2 senconds to topic `tumbling_topic`
+# We have created an agent `print_windowed_events` consuming events from
+# `tumbling_topic` that mutates the windowed table `table`
+
+# `table` is a table table with tumbling (non overlaping) windows. Each of its
+# windows is 10 seconds of duration. The table counts the number of events per
+# window. Since we produce an event every 2 seconds and our windows are 10
+# seconds of duration we only expect values between 1 and 5.
+
+from random import random
+from datetime import timedelta
+import faust
+
+app = faust.App('windowing',
+                broker='kafka://localhost:9092',
+                store='rocksdb://')
+
+
+class Model(faust.Record, serializer='json'):
+    random: float
+
+
+TOPIC = 'tumbling_topic'
+
+tumbling_topic = app.topic(TOPIC, value_type=Model)
+table = app.Table('tumbling_current_table', default=int) \
+           .tumbling(10, expires=timedelta(minutes=10))
+
+
+@app.agent(tumbling_topic)
+async def print_windowed_events(stream):
+    async for _ in stream: # noqa
+        table['counter'] += 1
+        print("Values should go from 1 to 5. Current window value: "
+              f"{table['counter'].current()}")
+
+
+@app.timer(2.0, on_leader=True)
+async def publish_every_2secs():
+    msg = Model(random=round(random(), 2))
+    await tumbling_topic.send(value=msg)
+    print(f"Producer just published message: {msg}")
+
+
+if __name__ == '__main__':
+    app.main()

--- a/faust/tables/wrappers.py
+++ b/faust/tables/wrappers.py
@@ -201,7 +201,7 @@ class WindowWrapper(WindowWrapperT):
         return self.table._windowed_contains(key, self.get_timestamp())
 
     def __getitem__(self, key: Any) -> WindowSetT:
-        return WindowSet(key, self.table, self)
+        return WindowSet(key, self.table, self, current_event())
 
     def __setitem__(self, key: Any, value: Any) -> None:
         if not isinstance(value, WindowSetT):


### PR DESCRIPTION

## Description

In this PR I attempt to fix the way `current()` works when calling it with no event.

I've created [this example](https://github.com/omarrayward/faust/blob/window-current-example/examples/windowing/tumbling_current.py) using a tumbling window and `current()`  and it was throwing this error:

```
[2018-11-02 11:40:02,608: ERROR]: [^---Agent*: tumbling[.]print_windowed_events]: Crashed reason=RuntimeError('Outside of stream iteration')
Traceback (most recent call last):
  File "/Users/omarrayward/faust/faust/agents/agent.py", line 559, in _execute_task
    await coro
  File "/Users/omarrayward/faust/examples/windowing/tumbling_current.py", line 37, in print_windowed_events
    print("Values should go from 1 to 5. Current window value: "
  File "/Users/omarrayward/faust/faust/tables/wrappers.py", line 85, in current
    self.key, t._relative_event(event or self.event))
  File "/Users/omarrayward/faust/faust/tables/base.py", line 372, in _relative_event
    raise RuntimeError('Outside of stream iteration')
RuntimeError: Outside of stream iteration
```

![current_before_fix](https://user-images.githubusercontent.com/1934424/47934262-1f82ec00-de94-11e8-97d3-e6d0af45f57c.gif)

The problem ends up being that `WindowSet` can be initialized with [`an event`](https://github.com/robinhood/faust/blob/52f5faea2e4c984fc9b97bb997b978bad14ce7a4/faust/tables/wrappers.py#L63), but currently in the [running code it never is](https://github.com/robinhood/faust/blob/52f5faea2e4c984fc9b97bb997b978bad14ce7a4/faust/tables/wrappers.py#L204).

In this PR when creating the `WindowSet` (windowed_table[<key>]) we assign `current_event()` as the event to be attached to that `WindowSet`.

After the code changes:
![current_after_fix](https://user-images.githubusercontent.com/1934424/47934594-e9923780-de94-11e8-880c-843e920ba6a6.gif)

