### PR TITLE
JSON serialize NamedTuples as lists, not dicts

### DIFF
--- a/faust/utils/json.py
+++ b/faust/utils/json.py
@@ -28,7 +28,11 @@ try:  # pragma: no cover
 
     # simplejson converts Decimal to float by default, i.e. before
     # we have a chance to override it using Encoder.default.
-    _JSON_DEFAULT_KWARGS = {'use_decimal': False}
+    _JSON_DEFAULT_KWARGS = {
+        'use_decimal': False,
+        'namedtuple_as_object': False
+    }
+
 except ImportError:  # pragma: no cover
     import json  # type: ignore
     _JSON_DEFAULT_KWARGS = {}

--- a/t/unit/windows/test_window_range.py
+++ b/t/unit/windows/test_window_range.py
@@ -1,0 +1,9 @@
+from faust.windows import WindowRange
+from faust.utils.json import dumps
+
+
+class test_WindowRange:
+
+    def test_window_range_json_dump(self):
+        serialized = dumps(WindowRange(1, 2))
+        assert serialized == '[1, 2]'


### PR DESCRIPTION

## Description

Fixes https://github.com/robinhood/faust/issues/200
Turns out that simplejson's default way of serializing a NamedTuple is as an object instead of a list. 

We use `WindowRange` (a `NamedTuple`) as the second element of the key for windowed tables. 
When storing the values in the changelog topic the `WindowRange` was serialized to a json object, e.g. `'{"start": 0, "end": 1}'`

But when recovering the value from the kafka changelog topic, the `WindowRange` value was recovered as a python dictionary, e.g.. `{"start": 0, "end": 1}`

The in-memory store (python dictionary) is able to handle a `NamedTuple` as part of a key (it's hashable), but not a python dictionary, hence the error when [executing this line of code](https://github.com/robinhood/faust/blob/52f5faea2e4c984fc9b97bb997b978bad14ce7a4/faust/stores/memory.py#L33).

In this PR a `NamedTuple` is serialized to a list instead of an object, which gets converted to a tuple(hashable) before updating the in-memory python dictionary.




