### PR TITLE
Add crontab functionality

### DIFF
--- a/docs/_ext/faustdocs.py
+++ b/docs/_ext/faustdocs.py
@@ -25,6 +25,7 @@ APPDIRECT = {
     'agent',
     'task',
     'timer',
+    'crontab',
     'stream',
     'Table',
     'Set',

--- a/docs/reference/faust.utils.cron.rst
+++ b/docs/reference/faust.utils.cron.rst
@@ -1,0 +1,10 @@
+``faust.utils.cron``
+=====================================================
+
+.. contents::
+   :local:
+.. currentmodule:: faust.utils.cron
+
+.. automodule:: faust.utils.cron
+   :members:
+   :undoc-members:

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -174,6 +174,7 @@ Utils
     :maxdepth: 1
 
     faust.utils.codegen
+    faust.utils.cron
     faust.utils.functional
     faust.utils.iso8601
     faust.utils.json

--- a/docs/userguide/tasks.rst
+++ b/docs/userguide/tasks.rst
@@ -1,8 +1,8 @@
 .. _guide-tasks:
 
-============================================
- Tasks, Timers, Web Views, and CLI Commands
-============================================
+======================================================
+ Tasks, Timers, Cron Jobs, Web Views, and CLI Commands
+======================================================
 
 .. contents::
     :local:
@@ -54,6 +54,36 @@ A timer is a task that executes every ``n`` seconds:
 
 After starting the worker, and it's operational, the above timer will print
 something every minute.
+
+.. _tasks-cron-jobs:
+
+Cron Jobs
+=========
+
+A cron job is a task that executes according to a crontab format,
+usually at fixed times:
+
+.. sourcecode:: python
+
+    @app.crontab('0 20 * * *')
+    async def every_dat_at_8_pm():
+        print('WAKE UP ONCE A DAY')
+
+
+After starting the worker, and it's operational, the above cron job will print
+something every day at 8pm.
+
+``crontab`` takes 1 mandatory argument ``cron_format`` and 2 optional arguments:
+
+- ``tz``, represents the timezone. Defaults to None which gives behaves as UTC.
+- ``on_leader``, boolean defaults to False, only run on leader?
+
+.. sourcecode:: python
+
+    @app.crontab('0 20 * * *', tz=pytz.timezone('US/Pacific'), on_leader=True)
+    async def every_dat_at_8_pm_pacific():
+        print('WAKE UP AT 8:00pm PACIFIC TIME ONLY ON THE LEADER WORKER')
+
 
 .. _tasks-web-views:
 

--- a/examples/crontab/tz_aware.py
+++ b/examples/crontab/tz_aware.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+
+# This example needs pytz so that we can set the approprate timezone when
+# setting the crontab
+
+from random import random
+from datetime import datetime
+import faust
+import pytz
+
+app = faust.App('tz_aware', broker='kafka://localhost:9092')
+pacific = pytz.timezone('US/Pacific')
+
+
+class Model(faust.Record, serializer='json'):
+    random: float
+
+
+tz_aware_topic = app.topic('tz_aware_topic', value_type=Model)
+
+
+@app.agent(tz_aware_topic)
+async def print_every_minute(stream):
+    async for record in stream:
+        print(f'record: {record}')
+
+
+@app.crontab('16 20 * * *', tz=pacific, on_leader=True)
+async def publish_every_2secs():
+    print('-- This should be sent at 20:16 Pacific time --')
+    print(f'Sending message at: {datetime.now()}')
+    msg = Model(random=round(random(), 2))
+    await tz_aware_topic.send(value=msg)
+
+
+if __name__ == '__main__':
+    app.main()

--- a/examples/crontab/tz_aware.py
+++ b/examples/crontab/tz_aware.py
@@ -20,13 +20,13 @@ tz_aware_topic = app.topic('tz_aware_topic', value_type=Model)
 
 
 @app.agent(tz_aware_topic)
-async def print_every_minute(stream):
+async def consume(stream):
     async for record in stream:
         print(f'record: {record}')
 
 
 @app.crontab('16 20 * * *', tz=pacific, on_leader=True)
-async def publish_every_2secs():
+async def publish_at_8_20_pm_pacific():
     print('-- This should be sent at 20:16 Pacific time --')
     print(f'Sending message at: {datetime.now()}')
     msg = Model(random=round(random(), 2))

--- a/examples/crontab/tz_unaware.py
+++ b/examples/crontab/tz_unaware.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+
+from random import random
+from datetime import datetime
+import faust
+
+app = faust.App('tz_unaware', broker='kafka://localhost:9092')
+
+
+class Model(faust.Record, serializer='json'):
+    random: float
+
+
+tz_unaware_topic = app.topic('tz_unaware_topic', value_type=Model)
+
+
+@app.agent(tz_unaware_topic)
+async def print_every_minute(stream):
+    async for record in stream:
+        print(f'record: {record}')
+
+
+@app.crontab('*/1 * * * *', on_leader=True)
+async def publish_every_2secs():
+    print('-- We should send a message every minute --')
+    print(f'Sending message at: {datetime.now()}')
+    msg = Model(random=round(random(), 2))
+    await tz_unaware_topic.send(value=msg)
+
+
+if __name__ == '__main__':
+    app.main()

--- a/examples/crontab/tz_unaware.py
+++ b/examples/crontab/tz_unaware.py
@@ -15,13 +15,13 @@ tz_unaware_topic = app.topic('tz_unaware_topic', value_type=Model)
 
 
 @app.agent(tz_unaware_topic)
-async def print_every_minute(stream):
+async def consume(stream):
     async for record in stream:
         print(f'record: {record}')
 
 
 @app.crontab('*/1 * * * *', on_leader=True)
-async def publish_every_2secs():
+async def publish_every_minute():
     print('-- We should send a message every minute --')
     print(f'Sending message at: {datetime.now()}')
     msg = Model(random=round(random(), 2))

--- a/faust/app/base.py
+++ b/faust/app/base.py
@@ -52,7 +52,7 @@ from faust.channels import Channel, ChannelT
 from faust.exceptions import ImproperlyConfigured, SameNode
 from faust.fixups import FixupT, fixups
 from faust.sensors import Monitor, SensorDelegate
-from faust.utils import venusian
+from faust.utils import venusian, cron
 from faust.web import drivers as web_drivers
 from faust.web.cache import backends as cache_backends
 from faust.web.views import View
@@ -800,6 +800,54 @@ class App(AppT, Service):
             # but we always call @app.task() - with parens, so return value is
             # always TaskArg.
             return cast(TaskArg, around_timer)
+
+        return _inner
+
+    def crontab(self, cron_format: str, tz: any = None,
+                on_leader: bool = False) -> Callable:
+        """Define an async def function to be run at the fixed times,
+        defined by the cron format.
+
+        Like :meth:`timer`, but executes at fixed times instead of executing
+        at certain intervals.
+
+        This decorator takes an async function and adds it to a
+        list of cronjobs started with the app.
+
+        Arguments:
+            cron_format (str): The cron spec defining fixed times to run the
+            decorated function.
+
+            tz (tzinfo) = None: The timezone to be taken into account for
+            the cron jobs
+
+            on_leader (bool) = False: Should the cron job only run on the
+            leader?
+
+        Example:
+            >>> @app.crontab(cron_format='30 18 * * *',
+                             tz=pytz.timezone('US/Pacific'))
+            >>> async def every_6_30_pm_pacific():
+            ...     print('IT IS 6:30pm')
+
+
+            >>> app.crontab(cron_format='30 18 * * *', on_leader=True)
+            >>> async def every_6_30_pm():
+            ...     print('6:30pm UTC; ALSO, I AM THE LEADER!')
+        """
+
+        def _inner(fun: TaskArg) -> TaskArg:
+            @self.task
+            @wraps(fun)
+            async def cron_starter(*args: Any) -> None:
+                while not self.should_stop:                    
+                    await asyncio.sleep(cron.secs_for_next(cron_format, tz))
+
+                    should_run = not on_leader or self.is_leader()
+                    if should_run:
+                        await fun(*args)  # type: ignore
+
+            return cast(TaskArg, cron_starter)
 
         return _inner
 

--- a/faust/app/base.py
+++ b/faust/app/base.py
@@ -10,6 +10,7 @@ import inspect
 import re
 import typing
 import warnings
+from datetime import tzinfo
 from functools import wraps
 from itertools import chain
 from typing import (
@@ -803,7 +804,7 @@ class App(AppT, Service):
 
         return _inner
 
-    def crontab(self, cron_format: str, tz: Any = None,
+    def crontab(self, cron_format: str, tz: tzinfo = None,
                 on_leader: bool = False) -> Callable:
         """Define an async def function to be run at the fixed times,
         defined by the cron format.

--- a/faust/app/base.py
+++ b/faust/app/base.py
@@ -52,7 +52,7 @@ from faust.channels import Channel, ChannelT
 from faust.exceptions import ImproperlyConfigured, SameNode
 from faust.fixups import FixupT, fixups
 from faust.sensors import Monitor, SensorDelegate
-from faust.utils import venusian, cron
+from faust.utils import cron, venusian
 from faust.web import drivers as web_drivers
 from faust.web.cache import backends as cache_backends
 from faust.web.views import View
@@ -803,7 +803,7 @@ class App(AppT, Service):
 
         return _inner
 
-    def crontab(self, cron_format: str, tz: any = None,
+    def crontab(self, cron_format: str, tz: Any = None,
                 on_leader: bool = False) -> Callable:
         """Define an async def function to be run at the fixed times,
         defined by the cron format.
@@ -840,7 +840,7 @@ class App(AppT, Service):
             @self.task
             @wraps(fun)
             async def cron_starter(*args: Any) -> None:
-                while not self.should_stop:                    
+                while not self.should_stop:
                     await asyncio.sleep(cron.secs_for_next(cron_format, tz))
 
                     should_run = not on_leader or self.is_leader()

--- a/faust/types/app.py
+++ b/faust/types/app.py
@@ -1,6 +1,7 @@
 import abc
 import asyncio
 import typing
+from datetime import tzinfo
 from typing import (
     Any,
     AsyncIterable,
@@ -192,7 +193,7 @@ class AppT(ServiceT):
     @abc.abstractmethod
     def crontab(self,
                 cron_format: str,
-                tz: Any = None,
+                tz: tzinfo = None,
                 on_leader: bool = False) -> Callable:
         ...
 

--- a/faust/types/app.py
+++ b/faust/types/app.py
@@ -192,7 +192,7 @@ class AppT(ServiceT):
     @abc.abstractmethod
     def crontab(self,
                 cron_format: str,
-                tz: any = None,
+                tz: Any = None,
                 on_leader: bool = False) -> Callable:
         ...
 

--- a/faust/types/app.py
+++ b/faust/types/app.py
@@ -190,6 +190,13 @@ class AppT(ServiceT):
         ...
 
     @abc.abstractmethod
+    def crontab(self,
+                cron_format: str,
+                tz: any = None,
+                on_leader: bool = False) -> Callable:
+        ...
+
+    @abc.abstractmethod
     def service(self, cls: Type[ServiceT]) -> Type[ServiceT]:
         ...
 

--- a/faust/utils/cron.py
+++ b/faust/utils/cron.py
@@ -1,0 +1,14 @@
+import datetime
+import time
+from croniter.croniter import croniter
+
+
+def secs_for_next(cron_format: str, tz: any = None) -> float:
+    now_ts = time.time()
+    # If we have a tz object we'll make now timezone aware, and
+    # if not will set now to be the current timestamp (tz
+    # unaware)
+    # If we have tz, now will be a datetime, if not an integer
+    now = tz and datetime.datetime.now(tz) or now_ts
+    cron_it = croniter(cron_format, start_time=now)
+    return cron_it.get_next(float) - now_ts

--- a/faust/utils/cron.py
+++ b/faust/utils/cron.py
@@ -1,9 +1,10 @@
 import datetime
 import time
 from croniter.croniter import croniter
+from typing import Any
 
 
-def secs_for_next(cron_format: str, tz: any = None) -> float:
+def secs_for_next(cron_format: str, tz: Any = None) -> float:
     now_ts = time.time()
     # If we have a tz object we'll make now timezone aware, and
     # if not will set now to be the current timestamp (tz

--- a/faust/utils/cron.py
+++ b/faust/utils/cron.py
@@ -1,15 +1,14 @@
-import datetime
+from datetime import datetime, tzinfo
 import time
 from croniter.croniter import croniter
-from typing import Any
 
 
-def secs_for_next(cron_format: str, tz: Any = None) -> float:
+def secs_for_next(cron_format: str, tz: tzinfo = None) -> float:
     now_ts = time.time()
     # If we have a tz object we'll make now timezone aware, and
     # if not will set now to be the current timestamp (tz
     # unaware)
     # If we have tz, now will be a datetime, if not an integer
-    now = tz and datetime.datetime.now(tz) or now_ts
+    now = tz and datetime.now(tz) or now_ts
     cron_it = croniter(cron_format, start_time=now)
     return cron_it.get_next(float) - now_ts

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -6,3 +6,4 @@ mode>=2.0.3,<3.0
 terminaltables>=3.1,<4.0
 venusian>=1.1,<2.0
 yarl>=1.0,<2.0
+croniter>=0.3.16

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,4 +1,5 @@
 hypothesis>=3.31
+freezegun>=0.3.11
 pytest-aiofiles>=0.2.0
 pytest-aiohttp>=0.3.0
 pytest-asyncio>=0.8
@@ -8,6 +9,7 @@ pytest-openfiles>=0.2.0
 pytest-random-order>=0.5.4
 pytest-xdist>=1.20
 pytest~=3.0
+pytz>=2018.7 
 -r extras/datadog.txt
 -r extras/redis.txt
 -r extras/statsd.txt

--- a/t/unit/app/test_base.py
+++ b/t/unit/app/test_base.py
@@ -279,6 +279,22 @@ class test_App:
         await foo()
         did_execute.assert_called_once_with()
 
+    @pytest.mark.asyncio
+    async def test_crontab(self, *, app):
+        did_execute = Mock(name='did_execute')
+        app._producer = Mock(name='producer', flush=AsyncMock())
+
+        with patch('faust.app.base.cron') as cron:
+            cron.secs_for_next.return_value = 0.1
+
+            @app.crontab('* * * * *')
+            async def foo():
+                did_execute()
+                await app.stop()
+
+            await foo()
+            did_execute.assert_called_once_with()
+
     def test_service(self, *, app):
 
         @app.service

--- a/t/unit/utils/test_cron.py
+++ b/t/unit/utils/test_cron.py
@@ -1,0 +1,30 @@
+import pytz
+from freezegun import freeze_time
+from faust.utils.cron import secs_for_next
+
+SECS_IN_HOUR = 60 * 60
+
+
+@freeze_time('2000-01-01 00:00:00')
+def test_secs_for_next():
+    every_minute_cron_format = '*/1 * * * *'
+    assert secs_for_next(every_minute_cron_format) == 60
+
+    every_8pm_cron_format = '0 20 * * *'
+    assert secs_for_next(every_8pm_cron_format) == 20 * SECS_IN_HOUR
+
+    every_4th_july_1pm_cron_format = '0 13 4 7 *'
+    days_until_4th_july = 31 + 28 + 31 + 30 + 31 + 30 + 4
+    secs_until_4th_july = SECS_IN_HOUR * 24 * days_until_4th_july
+    secs_until_1_pm = 13 * SECS_IN_HOUR
+    total_secs = secs_until_4th_july + secs_until_1_pm
+    assert secs_for_next(every_4th_july_1pm_cron_format) == total_secs
+
+
+@freeze_time('2000-01-01 00:00:00')
+def test_secs_for_next_with_tz():
+    pacific = pytz.timezone('US/Pacific')
+
+    every_8pm_cron_format = '0 20 * * *'
+    # In Pacific time it's 16:00 so only 4 hours until 8:00pm
+    assert secs_for_next(every_8pm_cron_format, tz=pacific) == 4 * SECS_IN_HOUR


### PR DESCRIPTION
## Description

Adds crontab functionality to `App`

This is how we call it:

```python
....
@app.crontab('*/1 * * * *', on_leader=True)
async def publish_every_minute():
    print('-- We should send a message every minute --')
    print(f'Sending message at: {datetime.now()}')
    msg = Model(random=round(random(), 2))
    await tz_unaware_topic.send(value=msg)
```

```python
import pytz
pacific = pytz.timezone('US/Pacific')
@app.crontab('16 20 * * *', tz=pacific, on_leader=True)
async def publish_every_8_20_pm_pacific():
    print('-- This should be sent at 20:16 Pacific time --')
    print(f'Sending message at: {datetime.now()}')
    msg = Model(random=round(random(), 2))
    await tz_aware_topic.send(value=msg)
```

This PR adds one dependency to the project: [`croniter>=0.3.16`](https://github.com/taichino/croniter) which we are using to know how much time we have to `await.sleep` until its time for the next cron job to run. 


@ask Leaving a couple of comments in code, that would like to address before merging. 

