### PR TITLE
Add `broker_request_timeout` app setting

### DIFF
--- a/docs/userguide/settings.rst
+++ b/docs/userguide/settings.rst
@@ -409,6 +409,18 @@ You shouldn't have to set this manually.
 The client id is used to identify the software used, and is not usually
 configured by the user.
 
+.. setting:: broker_request_timeout
+
+``broker_request_timeout``
+--------------------------
+
+.. versionadded:: 1.4.0
+
+:type: :class:`int`
+:default: ``40.0`` (fourty seconds)
+
+Kafka client request timeout.
+
 .. setting:: broker_commit_every
 
 ``broker_commit_every``

--- a/faust/transport/drivers/aiokafka.py
+++ b/faust/transport/drivers/aiokafka.py
@@ -235,6 +235,7 @@ class Consumer(base.Consumer):
             max_poll_records=None,
             max_partition_fetch_bytes=1048576 * 4,
             fetch_max_wait_ms=1500,
+            request_timeout_ms=int(conf.broker_request_timeout * 1000.0),
             check_crcs=conf.broker_check_crcs,
             session_timeout_ms=int(conf.broker_session_timeout * 1000.0),
             heartbeat_interval_ms=int(conf.broker_heartbeat_interval * 1000.0),
@@ -251,6 +252,7 @@ class Consumer(base.Consumer):
             client_id=app.conf.broker_client_id,
             bootstrap_servers=server_list(
                 transport.url, transport.default_port),
+            request_timeout_ms=int(app.conf.broker_request_timeout * 1000.0),
             enable_auto_commit=True,
             auto_offset_reset='earliest',
             check_crcs=app.conf.broker_check_crcs,

--- a/t/functional/test_app.py
+++ b/t/functional/test_app.py
@@ -38,6 +38,7 @@ class test_settings:
         assert conf.datadir == conf._prepare_datadir(settings.DATADIR)
         assert conf.tabledir == conf._prepare_tabledir(settings.TABLEDIR)
         assert conf.broker_client_id == settings.BROKER_CLIENT_ID
+        assert conf.broker_request_timeout == settings.BROKER_REQUEST_TIMEOUT
         assert conf.broker_session_timeout == settings.BROKER_SESSION_TIMEOUT
         assert (conf.broker_heartbeat_interval ==
                 settings.BROKER_HEARTBEAT_INTERVAL)
@@ -140,6 +141,7 @@ class test_settings:
                                  broker_client_id='client id',
                                  datadir='/etc/faust/',
                                  tabledir='/var/faust/',
+                                 broker_request_timeout=10000.05,
                                  broker_heartbeat_interval=101.13,
                                  broker_session_timeout=30303.30,
                                  broker_commit_every=202,
@@ -183,6 +185,7 @@ class test_settings:
             broker_client_id=broker_client_id,
             datadir=datadir,
             tabledir=tabledir,
+            broker_request_timeout=broker_request_timeout,
             broker_session_timeout=broker_session_timeout,
             broker_heartbeat_interval=broker_heartbeat_interval,
             broker_commit_every=broker_commit_every,
@@ -226,6 +229,7 @@ class test_settings:
             assert conf.tabledir == Path(str(tabledir))
         else:
             assert conf.tabledir.relative_to(conf.appdir) == Path(tabledir)
+        assert conf.broker_request_timeout == broker_request_timeout
         assert conf.broker_heartbeat_interval == broker_heartbeat_interval
         assert conf.broker_session_timeout == broker_session_timeout
         assert conf.broker_commit_every == broker_commit_every


### PR DESCRIPTION
Addresses #219 

Add a `broker_request_timeout` setting to define `AIOKafkaConsumer`'s `request_timeout_ms` argument from Faust.