### PR TITLE
made max consumer fetch size configurable

### DIFF
--- a/docs/userguide/settings.rst
+++ b/docs/userguide/settings.rst
@@ -485,6 +485,22 @@ Increase this if you experience the cluster being in a state of constantly
 rebalancing, but make sure you also increase the
 :setting:`broker_heartbeat_interval` at the same time.
 
+.. _settings-consumer:
+
+Advanced Consumer Settings
+==========================
+
+.. setting:: consumer_max_fetch_size
+
+``consumer_max_fetch_size``
+---------------------------
+
+:type: :class:`int`
+:default: ``4*1024**2``
+
+The maximum amount of data per-partition the server will return. This size
+must be at least as large as the maximum message size.
+
 .. _settings-producer:
 
 Advanced Producer Settings
@@ -603,6 +619,7 @@ and can be used as a template for your own partitioner:
         index &= 0x7fffffff
         index %= len(all_partitions)
         return all_partitions[index]
+
 
 .. _settings-table:
 

--- a/faust/transport/drivers/aiokafka.py
+++ b/faust/transport/drivers/aiokafka.py
@@ -233,7 +233,7 @@ class Consumer(base.Consumer):
             enable_auto_commit=False,
             auto_offset_reset='earliest',
             max_poll_records=None,
-            max_partition_fetch_bytes=1048576 * 4,
+            max_partition_fetch_bytes=conf.consumer_max_fetch_size,
             fetch_max_wait_ms=1500,
             check_crcs=conf.broker_check_crcs,
             session_timeout_ms=int(conf.broker_session_timeout * 1000.0),

--- a/faust/types/settings.py
+++ b/faust/types/settings.py
@@ -192,6 +192,10 @@ STREAM_RECOVERY_DELAY = 10.0
 #: is added in a later version.
 STREAM_PUBLISH_ON_COMMIT = False
 
+#: Maximum size of a request in bytes in the consumer.
+#: Used as the default value for :setting:`max_fetch_size`.
+CONSUMER_MAX_FETCH_SIZE = 4 * 1024 ** 2
+
 #: Minimum time to batch before sending out messages from the producer.
 #: Used as the default value for :setting:`linger_ms`.
 PRODUCER_LINGER_MS = 0
@@ -270,6 +274,7 @@ class Settings(abc.ABC):
     producer_max_batch_size: int = PRODUCER_MAX_BATCH_SIZE
     producer_acks: int = PRODUCER_ACKS
     producer_max_request_size: int = PRODUCER_MAX_REQUEST_SIZE
+    consumer_max_fetch_size: int = CONSUMER_MAX_FETCH_SIZE
     producer_compression_type: Optional[str] = PRODUCER_COMPRESSION_TYPE
     web_enabled: bool
     web_bind: str = WEB_BIND
@@ -389,6 +394,7 @@ class Settings(abc.ABC):
             producer_max_request_size: int = None,
             producer_compression_type: str = None,
             producer_partitioner: SymbolArg[PartitionerT] = None,
+            consumer_max_fetch_size: int = None,
             web_bind: str = None,
             web_port: int = None,
             web_host: str = None,
@@ -485,6 +491,8 @@ class Settings(abc.ABC):
             self.producer_compression_type = producer_compression_type
         if producer_partitioner is not None:
             self.producer_partitioner = producer_partitioner
+        if consumer_max_fetch_size is not None:
+            self.consumer_max_fetch_size = consumer_max_fetch_size
         if web_bind is not None:
             self.web_bind = web_bind
         if web_port is not None:


### PR DESCRIPTION
Make the max consumer fetch size configurable with the default being the previous hard coded value of 4MB.
