### PR TITLE
Key deserialization errors if using custom key serialization and key_index=True

### DIFF
--- a/faust/tables/wrappers.py
+++ b/faust/tables/wrappers.py
@@ -278,7 +278,7 @@ class WindowWrapper(WindowWrapperT):
 
         if self.key_index and self.key_index_table is None:
             self.key_index_table = self.table.app.Table(
-                f'{self.table.name}-key_index', value_type=int)
+                f'{self.table.name}-key_index', value_type=int, key_type=self.table.key_type)
         self._get_relative_timestamp = self._relative_handler(relative_to)
 
     def clone(self, relative_to: RelativeArg) -> WindowWrapperT:


### PR DESCRIPTION
```key_type``` is not being set for ```key_index``` tables. This results in deserialization errors when replaying the commit log if ```key_index=True``` and you're not using JSON for key values.
