### PR TITLE
Stability: Move Kafka consumer to separate thread

### DIFF
--- a/examples/withdrawals.py
+++ b/examples/withdrawals.py
@@ -50,6 +50,10 @@ country_to_total = app.Table(
 @app.agent(withdrawals_topic)
 async def track_user_withdrawal(withdrawals):
     async for withdrawal in withdrawals:
+        import time
+        print('+ SLEEP: %r' % (asyncio.get_event_loop(),))
+        time.sleep(10)
+        print('- SLEEP')
         user_to_total[withdrawal.user] += withdrawal.amount
 
 

--- a/examples/withdrawals.py
+++ b/examples/withdrawals.py
@@ -50,10 +50,6 @@ country_to_total = app.Table(
 @app.agent(withdrawals_topic)
 async def track_user_withdrawal(withdrawals):
     async for withdrawal in withdrawals:
-        import time
-        print('+ SLEEP: %r' % (asyncio.get_event_loop(),))
-        time.sleep(10)
-        print('- SLEEP')
         user_to_total[withdrawal.user] += withdrawal.amount
 
 

--- a/faust/exceptions.py
+++ b/faust/exceptions.py
@@ -45,3 +45,7 @@ class SameNode(FaustError):
 
 class ProducerSendError(FaustError):
     """Error while sending attached messages prior to commit"""
+
+
+class ConsumerNotStarted(FaustError):
+    """Error trying to perform operation on consumer not started."""

--- a/faust/tables/recovery.py
+++ b/faust/tables/recovery.py
@@ -417,13 +417,14 @@ class Recovery(Service):
                             offsets: Counter[TP],
                             title: str) -> None:
         # Seek to new offsets
+        new_offsets = {}
         for tp in tps:
             offset = offsets[tp]
             if offset == -1:
                 offset = 0
-            # FIXME Remove check when fixed offset-1 discrepancy
-            await consumer.seek(tp, offset)
-            assert await consumer.position(tp) == offset
+            new_offsets[tp] = offset
+        # FIXME Remove check when fixed offset-1 discrepancy
+        await consumer.seek_wait(new_offsets)
 
     @Service.task
     async def _slurp_changelogs(self) -> None:

--- a/faust/transport/drivers/aiokafka.py
+++ b/faust/transport/drivers/aiokafka.py
@@ -1,8 +1,11 @@
 """Message transport using :pypi:`aiokafka`."""
+import asyncio
+from inspect import isawaitable
 from typing import (
     Any,
     AsyncIterator,
     Awaitable,
+    Callable,
     ClassVar,
     Dict,
     Iterable,
@@ -39,14 +42,14 @@ from rhkafka.errors import (
 from rhkafka.partitioner.default import DefaultPartitioner
 from rhkafka.protocol.metadata import MetadataRequest_v1
 from mode import Seconds, Service, flight_recorder, get_logger, want_seconds
+from mode.threads import ServiceThread
 from mode.utils.compat import OrderedDict
-from mode.utils.futures import StampedeWrapper
+from mode.utils.futures import StampedeWrapper, notify
 from mode.utils.locks import Event
 from yarl import URL
 
 from faust.exceptions import ProducerSendError
 from faust.transport import base
-from faust.transport.consumer import CONSUMER_SEEKING
 from faust.types import AppT, ConsumerMessage, Message, RecordMetadata, TP
 from faust.types.transports import ConsumerT, ProducerT
 from faust.utils import terminal
@@ -131,53 +134,26 @@ class _TopicBuffer(Iterator):
 class ConsumerRebalanceListener(aiokafka.abc.ConsumerRebalanceListener):
     # kafka's ridiculous class based callback interface makes this hacky.
 
-    def __init__(self, consumer: ConsumerT) -> None:
-        self.consumer: ConsumerT = consumer
+    def __init__(self, thread: 'ConsumerThread') -> None:
+        self._thread: 'ConsumerThread' = thread
 
     async def on_partitions_revoked(
             self, revoked: Iterable[_TopicPartition]) -> None:
-        self.consumer.app.rebalancing = True
-        # see comment in on_partitions_assigned
-        consumer = cast(Consumer, self.consumer)
-        _revoked = cast(Set[TP], set(revoked))
-        # remove revoked partitions from active + paused tps.
-        if consumer._active_partitions is not None:
-            consumer._active_partitions.difference_update(_revoked)
-        consumer._paused_partitions.difference_update(_revoked)
-        # start callback chain of assigned callbacks.
-        await consumer.on_partitions_revoked(set(_revoked))
+        await self._thread.on_partitions_revoked(revoked)
 
     async def on_partitions_assigned(
             self, assigned: Iterable[_TopicPartition]) -> None:
-        # have to cast to Consumer since ConsumerT interface does not
-        # have this attribute (mypy currently thinks a Callable instance
-        # variable is an instance method).  Furthermore we have to cast
-        # the Kafka TopicPartition namedtuples to our description,
-        # that way they are typed and decoupled from the actual client
-        # implementation.
-        consumer = cast(Consumer, self.consumer)
-        _assigned = set(assigned)
-        # remove recently revoked tps from set of paused tps.
-        consumer._paused_partitions.intersection_update(_assigned)
-        # cache set of assigned partitions
-        cast(Set[TP], consumer._set_active_tps(_assigned))
-        # start callback chain of assigned callbacks.
-        #   need to copy set at this point, since we cannot have
-        #   the callbacks mutate our active list.
-        consumer._last_batch = None
-        await consumer.on_partitions_assigned(_assigned)
+        await self._thread.on_partitions_assigned(assigned)
 
 
 class Consumer(base.Consumer):
     """Kafka consumer using :pypi:`aiokafka`."""
-
     logger = logger
 
     RebalanceListener: ClassVar[Type[ConsumerRebalanceListener]]
     RebalanceListener = ConsumerRebalanceListener
 
-    _consumer: aiokafka.AIOKafkaConsumer
-    _rebalance_listener: ConsumerRebalanceListener
+    _thread: 'ConsumerThread'
     _active_partitions: Optional[Set[_TopicPartition]]
     _paused_partitions: Set[_TopicPartition]
     fetch_timeout: float = 10.0
@@ -190,16 +166,14 @@ class Consumer(base.Consumer):
     can_resume_flow: Event
 
     def on_init(self) -> None:
-        app = self.transport.app
-        transport = cast(Transport, self.transport)
-        self._rebalance_listener = self.RebalanceListener(self)
-        if app.client_only:
-            self._consumer = self._create_client_consumer(app, transport)
-        else:
-            self._consumer = self._create_worker_consumer(app, transport)
         self._active_partitions = None
         self._paused_partitions = set()
         self.can_resume_flow = Event()
+        self._thread = ConsumerThread(
+            self,
+            loop=self.loop,
+            beacon=self.beacon,
+        )
 
     async def on_restart(self) -> None:
         self.on_init()
@@ -208,7 +182,7 @@ class Consumer(base.Consumer):
         tps = self._active_partitions
         if tps is None:
             # need aiokafka._TopicPartition, not faust.TP
-            return self._set_active_tps(self._consumer.assignment())
+            return self._set_active_tps(self.assignment())
         return tps
 
     def _set_active_tps(self,
@@ -220,11 +194,12 @@ class Consumer(base.Consumer):
     def _create_worker_consumer(
             self,
             app: AppT,
-            transport: 'Transport') -> aiokafka.AIOKafkaConsumer:
+            transport: 'Transport',
+            loop: asyncio.AbstractEventLoop) -> aiokafka.AIOKafkaConsumer:
         conf = app.conf
         self._assignor = self.app.assignor
         return aiokafka.AIOKafkaConsumer(
-            loop=self.loop,
+            loop=loop,
             client_id=conf.broker_client_id,
             group_id=conf.id,
             bootstrap_servers=server_list(
@@ -245,9 +220,10 @@ class Consumer(base.Consumer):
     def _create_client_consumer(
             self,
             app: AppT,
-            transport: 'Transport') -> aiokafka.AIOKafkaConsumer:
+            transport: 'Transport',
+            loop: asyncio.AbstractEventLoop) -> aiokafka.AIOKafkaConsumer:
         return aiokafka.AIOKafkaConsumer(
-            loop=self.loop,
+            loop=loop,
             client_id=app.conf.broker_client_id,
             bootstrap_servers=server_list(
                 transport.url, transport.default_port),
@@ -270,9 +246,7 @@ class Consumer(base.Consumer):
                            compacting: bool = None,
                            deleting: bool = None,
                            ensure_created: bool = False) -> None:
-        await cast(Transport, self.transport)._create_topic(
-            self,
-            self._consumer._client,
+        await self._thread.create_topic(
             topic,
             partitions,
             replication,
@@ -285,34 +259,25 @@ class Consumer(base.Consumer):
         )
 
     async def on_start(self) -> None:
-        self.beacon.add(self._consumer)
-        await self._consumer.start()
+        await self._thread.start()
 
     async def subscribe(self, topics: Iterable[str]) -> None:
-        # XXX pattern does not work :/
-        self._consumer.subscribe(
-            topics=set(topics),
-            listener=self._rebalance_listener,
-        )
+        await self._thread.subscribe(topics=topics)
 
     async def getmany(self,
                       timeout: float) -> AsyncIterator[Tuple[TP, Message]]:
+        if not self.flow_active:
+            await self.wait(self.can_resume_flow)
         # Implementation for the Fetcher service.
-        _consumer = self._consumer
-        fetcher = _consumer._fetcher
-        if _consumer._closed or fetcher._closed:
-            raise ConsumerStoppedError()
         active_partitions = self._get_active_partitions()
         _next = next
 
         records: RecordMap = {}
-        if not self.flow_active:
-            await self.wait(self.can_resume_flow)
         if active_partitions:
             # Fetch records only if active partitions to avoid the risk of
             # fetching all partitions in the beginning when none of the
             # partitions is paused/resumed.
-            records = await fetcher.fetched_records(
+            records = await self._thread.getmany(
                 active_partitions,
                 timeout=timeout,
             )
@@ -386,7 +351,7 @@ class Consumer(base.Consumer):
                     continue
                 tp, record = item  # type: ignore
                 if tp in active_partitions:
-                    highwater_mark = self._consumer.highwater(tp)
+                    highwater_mark = self._thread.highwater(tp)
                     self.app.monitor.track_tp_end_offset(tp, highwater_mark)
                     # convert timestamp to seconds from int milliseconds.
                     timestamp: Optional[int] = record.timestamp
@@ -428,16 +393,13 @@ class Consumer(base.Consumer):
     async def on_stop(self) -> None:
         await super().on_stop()  # wait_empty
         await self.commit()
-        await self._consumer.stop()
+        await self._thread.stop()
         transport = cast(Transport, self.transport)
         transport._topic_waiters.clear()
 
     async def perform_seek(self) -> None:
-        await self.transition_with(CONSUMER_SEEKING, self._perform_seek())
-
-    async def _perform_seek(self) -> None:
         read_offset = self._read_offset
-        _committed_offsets = await self._consumer.seek_to_committed()
+        _committed_offsets = await self._thread.seek_to_committed()
         committed_offsets = {
             _ensure_TP(tp): offset
             for tp, offset in _committed_offsets.items()
@@ -479,7 +441,7 @@ class Consumer(base.Consumer):
                 return False
             with flight_recorder(self.log, timeout=300.0) as on_timeout:
                 on_timeout.info('+aiokafka_consumer.commit()')
-                await self._consumer.commit(commitable)
+                await self._thread.commit(commitable)
                 on_timeout.info('-aiokafka._consumer.commit()')
             self._committed_offset.update(commitable_offsets)
             self.app.monitor.on_tp_commit(commitable_offsets)
@@ -516,12 +478,12 @@ class Consumer(base.Consumer):
         self._paused_partitions.difference_update(tpset)
 
     async def position(self, tp: TP) -> Optional[int]:
-        return await self._consumer.position(tp)
+        return await self._thread.position(tp)
 
     async def _seek_to_beginning(self, *partitions: TP) -> None:
         self.log.dev('SEEK TO BEGINNING: %r', partitions)
         self._read_offset.update((_ensure_TP(tp), None) for tp in partitions)
-        await self._consumer.seek_to_beginning(*(
+        await self._thread.seek_to_beginning(*(
             self._new_topicpartition(tp.topic, tp.partition)
             for tp in partitions
         ))
@@ -532,24 +494,234 @@ class Consumer(base.Consumer):
         self._last_batch = None
         # set new read offset so we will reread messages
         self._read_offset[_ensure_TP(partition)] = offset if offset else None
-        self._consumer.seek(partition, offset)
+        self._thread.seek(partition, offset)
 
     def assignment(self) -> Set[TP]:
-        return cast(Set[TP], self._consumer.assignment())
+        return self._thread.assignment()
 
     def highwater(self, tp: TP) -> int:
-        return self._consumer.highwater(tp)
+        return self._thread.highwater(tp)
 
     async def earliest_offsets(self,
                                *partitions: TP) -> MutableMapping[TP, int]:
-        return await self._consumer.beginning_offsets(partitions)
+        return await self._thread.earliest_offsets(*partitions)
 
     async def highwaters(self, *partitions: TP) -> MutableMapping[TP, int]:
-        return await self._consumer.end_offsets(partitions)
+        return await self._thread.highwaters(*partitions)
 
     def close(self) -> None:
-        self._consumer.set_close()
-        self._consumer._coordinator.set_close()
+        self._thread.close()
+
+
+class ConsumerThread(ServiceThread):
+    consumer: Consumer
+    _consumer_started: Optional[asyncio.Future] = None
+    app: AppT
+    _consumer: Optional[aiokafka.AIOKafkaConsumer] = None
+    _method_queue: Optional[asyncio.Queue] = None
+
+    def __init__(self, consumer: Consumer, **kwargs: Any) -> None:
+        self.consumer = consumer
+        transport = consumer.transport
+        self.app = transport.app
+        self._rebalance_listener = consumer.RebalanceListener(self)
+        super().__init__(**kwargs)
+
+    @property
+    def method_queue(self) -> asyncio.Queue:
+        if self._method_queue is None:
+            self._method_queue = asyncio.Queue(loop=self.thread_loop)
+        return self._method_queue
+
+    async def call_method(self,
+                          method: Callable[..., Awaitable],
+                          *args: Any,
+                          **kwargs: Any) -> Any:
+        future = self.parent_loop.create_future()
+        await self.method_queue.put((future, method, args, kwargs))
+        return await future
+
+    @Service.task
+    async def _method_handler(self) -> None:
+        while not self.should_stop:
+            future, method, args, kwargs = await self.method_queue.get()
+            try:
+                result = method(*args, **kwargs)
+                if isawaitable(result):
+                    result = await result
+                future.set_result(result)
+            except BaseException as exc:
+                future.set_exception(exc)
+
+    @Service.task
+    async def _keepalive(self) -> None:
+        while not self.should_stop:
+            await asyncio.sleep(1)
+
+    async def start(self) -> None:  # pragma: no cover
+        self._consumer_started = asyncio.Future(loop=self.parent_loop)
+        await super().start()
+        # thread exceptions do not propagate to the main thread, so we
+        # need some way to communicate socket open errors, such as "port in
+        # use", back to the parent thread.  The _port_open future is set to
+        # an exception state when that happens, and awaiting will propagate
+        # the error to the parent thread.
+        if not self.should_stop:
+            try:
+                await self._consumer_started
+            finally:
+                self._consumer_started = None
+
+    async def crash(self, exc: BaseException) -> None:
+        if self._consumer_started and not self._consumer_started.done():
+            # .start() will raise
+            self._consumer_started.set_exception(exc)
+        await super().crash(exc)
+
+    async def on_start(self) -> None:
+        app = self.app
+        consumer = self.consumer
+        transport = cast(Transport, consumer.transport)
+        if self.app.client_only:
+            self._consumer = consumer._create_client_consumer(
+                app, transport, loop=self.thread_loop)
+        else:
+            self._consumer = consumer._create_worker_consumer(
+                app, transport, loop=self.thread_loop)
+        await self._ensure_consumer().start()
+        notify(self._consumer_started)  # <- .start() can return now
+
+    async def on_thread_stop(self) -> None:
+        if self._consumer is not None:
+            await self._consumer.stop()
+
+    def close(self) -> None:
+        if self._consumer is not None:
+            self._consumer.set_close()
+            self._consumer._coordinator.set_close()
+
+    async def on_partitions_revoked(
+            self, revoked: Iterable[_TopicPartition]) -> None:
+        self.consumer.app.rebalancing = True
+        # see comment in on_partitions_assigned
+        consumer = self.consumer
+        _revoked = cast(Set[TP], set(revoked))
+        # remove revoked partitions from active + paused tps.
+        if consumer._active_partitions is not None:
+            consumer._active_partitions.difference_update(_revoked)
+        consumer._paused_partitions.difference_update(_revoked)
+        # start callback chain of assigned callbacks.
+        await consumer.on_partitions_revoked(set(_revoked))
+
+    async def on_partitions_assigned(
+            self, assigned: Iterable[_TopicPartition]) -> None:
+        # have to cast to Consumer since ConsumerT interface does not
+        # have this attribute (mypy currently thinks a Callable instance
+        # variable is an instance method).  Furthermore we have to cast
+        # the Kafka TopicPartition namedtuples to our description,
+        # that way they are typed and decoupled from the actual client
+        # implementation.
+        consumer = self.consumer
+        _assigned = set(assigned)
+        # remove recently revoked tps from set of paused tps.
+        consumer._paused_partitions.intersection_update(_assigned)
+        # cache set of assigned partitions
+        cast(Set[TP], consumer._set_active_tps(_assigned))
+        # start callback chain of assigned callbacks.
+        #   need to copy set at this point, since we cannot have
+        #   the callbacks mutate our active list.
+        consumer._last_batch = None
+        await consumer.on_partitions_assigned(_assigned)
+
+    async def subscribe(self, topics: Iterable[str]) -> None:
+        # XXX pattern does not work :/
+        await self.call_method(
+            self._ensure_consumer().subscribe,
+            topics=set(topics),
+            listener=self._rebalance_listener,
+        )
+
+    async def seek_to_committed(self) -> Mapping[TP, int]:
+        return await self.call_method(
+            self._ensure_consumer().seek_to_committed)
+
+    async def commit(self, tps: Any) -> Any:
+        return await self.call_method(
+            self._ensure_consumer().commit, tps)
+
+    async def position(self, tp: TP) -> Optional[int]:
+        return await self.call_method(
+            self._ensure_consumer().position, tp)
+
+    async def seek_to_beginning(self, *partitions: _TopicPartition) -> None:
+        await self.call_method(
+            self._ensure_consumer().seek_to_beginning, *partitions)
+
+    def seek(self, partition: TP, offset: int) -> None:
+        self._ensure_consumer().seek(partition, offset)
+
+    def assignment(self) -> Set[TP]:
+        return cast(Set[TP], self._ensure_consumer().assignment())
+
+    def highwater(self, tp: TP) -> int:
+        return self._ensure_consumer().highwater(tp)
+
+    async def earliest_offsets(self,
+                               *partitions: TP) -> MutableMapping[TP, int]:
+        return await self.call_method(
+            self._ensure_consumer().beginning_offsets, partitions)
+
+    async def highwaters(self, *partitions: TP) -> MutableMapping[TP, int]:
+        return await self.call_method(
+            self._ensure_consumer().end_offsets, partitions)
+
+    def _ensure_consumer(self) -> aiokafka.AIOKafkaConsumer:
+        if self._consumer is None:
+            raise RuntimeError('Consumer thread not yet started')
+        return self._consumer
+
+    async def getmany(self,
+                      active_partitions: Set[_TopicPartition],
+                      timeout: float) -> RecordMap:
+        # Implementation for the Fetcher service.
+        _consumer = self._ensure_consumer()
+        fetcher = _consumer._fetcher
+        if _consumer._closed or fetcher._closed:
+            raise ConsumerStoppedError()
+        return await self.call_method(
+            fetcher.fetched_records,
+            active_partitions,
+            timeout=timeout,
+        )
+
+    async def create_topic(self,
+                           topic: str,
+                           partitions: int,
+                           replication: int,
+                           *,
+                           config: Mapping[str, Any] = None,
+                           timeout: Seconds = 30.0,
+                           retention: Seconds = None,
+                           compacting: bool = None,
+                           deleting: bool = None,
+                           ensure_created: bool = False) -> None:
+        consumer = self.consumer
+        transport = cast(Transport, consumer.transport)
+        _consumer = self._ensure_consumer()
+        await self.call_method(
+            transport._create_topic,
+            consumer,
+            _consumer._client,
+            topic,
+            partitions,
+            replication,
+            config=config,
+            timeout=int(want_seconds(timeout) * 1000.0),
+            retention=int(want_seconds(retention) * 1000.0),
+            compacting=compacting,
+            deleting=deleting,
+            ensure_created=ensure_created,
+        )
 
 
 class Producer(base.Producer):

--- a/faust/types/transports.py
+++ b/faust/types/transports.py
@@ -169,6 +169,10 @@ class ConsumerT(ServiceT):
         ...
 
     @abc.abstractmethod
+    async def seek_wait(self, partitions: Mapping[TP, int]) -> None:
+        ...
+
+    @abc.abstractmethod
     async def commit(self, topics: TPorTopicSet = None) -> bool:
         ...
 

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -2,7 +2,7 @@ aiohttp>=2.3.9,<4.0
 robinhood-aiokafka>=0.4.19,<1.0
 click>=6.7,<7.0
 colorclass>=2.2,<3.0
-mode
+mode>=3.0,<4.0
 terminaltables>=3.1,<4.0
 venusian>=1.1,<2.0
 yarl>=1.0,<2.0

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -2,7 +2,7 @@ aiohttp>=2.3.9,<4.0
 robinhood-aiokafka>=0.4.19,<1.0
 click>=6.7,<7.0
 colorclass>=2.2,<3.0
-mode>=2.1.0,<3.0
+mode
 terminaltables>=3.1,<4.0
 venusian>=1.1,<2.0
 yarl>=1.0,<2.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,1 +1,0 @@
-https://github.com/ask/mode/zipball/master#egg=mode

--- a/t/unit/transport/test_consumer.py
+++ b/t/unit/transport/test_consumer.py
@@ -74,6 +74,9 @@ class MyConsumer(Consumer):
     async def seek(self, *args, **kwargs):
         ...
 
+    async def seek_wait(self, *args, **kwargs):
+        ...
+
     async def subscribe(self, *args, **kwargs):
         ...
 

--- a/t/unit/web/drivers/test_aiohttp.py
+++ b/t/unit/web/drivers/test_aiohttp.py
@@ -17,22 +17,13 @@ class test_ServerThread:
         assert thread.web is web
 
     @pytest.mark.asyncio
-    async def test_on_start(self, *, thread):
-        thread.web.start_server = AsyncMock(name='web.start_server')
-        thread._port_open = asyncio.Future()
-        await thread.on_start()
-
-        assert thread._port_open.done()
-        thread.web.start_server.assert_called_once_with(thread.loop)
-
-    @pytest.mark.asyncio
     async def test_crash(self, *, thread):
-        thread._port_open = asyncio.Future()
+        thread._thread_running = asyncio.Future()
         exc = RuntimeError()
         await thread.crash(exc)
-        assert thread._port_open.exception() is exc
+        assert thread._thread_running.exception() is exc
 
-        thread._port_open = None
+        thread._thread_running = None
         await thread.crash(exc)
 
     @pytest.mark.asyncio

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,6 @@ deps=
     -r{toxinidir}/requirements/default.txt
     -r{toxinidir}/requirements/test.txt
     -r{toxinidir}/requirements/ci.txt
-    -r{toxinidir}/requirements/dev.txt
 
     linkcheck,apicheck,configcheck: -r{toxinidir}/requirements/docs.txt
     flake8: -r{toxinidir}/requirements/dist.txt


### PR DESCRIPTION
The Kafka heartbeat background corutine sends heartbeats every 3.0 seconds, and if those are missed rebalancing occurs.

This patch moves the aiokafka library inside a *separate thread*, this way it can send responsive
heartbeats and operate even when agents call blocking functions such as `time.sleep(60)` for every event.

Requires ask/mode@master