### PR TITLE
Fix 'aenumerate' typo in User Guide: Stream

### DIFF
--- a/docs/userguide/streams.rst
+++ b/docs/userguide/streams.rst
@@ -454,12 +454,12 @@ for an asynchronous stream:
         async for i, value in stream.enumerate():
             ...
 
-The count will start at zero by default, but ``aenumerate`` also accepts an
+The count will start at zero by default, but ``enumerate`` also accepts an
 optional starting point argument.
 
 .. seealso::
 
-    - The :func:`faust.utils.aiter.aenumerate` function -- for a general version
+    - The :func:`faust.utils.aiter.enumerate` function -- for a general version
       of :func:`enumerate` that let you enumerate any async iterator, not just
       streams.
 

--- a/docs/userguide/streams.rst
+++ b/docs/userguide/streams.rst
@@ -441,7 +441,7 @@ time with no events received it will still process what it has gathered.
 ``enumerate()`` -- Count values
 -------------------------------
 
-Use :meth:`Stream.aenumerate()` to keep a count of the number of values
+Use :meth:`Stream.enumerate()` to keep a count of the number of values
 seen so far in a stream.
 
 This operation works exactly like the Python :func:`enumerate` function, but


### PR DESCRIPTION

## Description

I fixed a typo. :) 