### PR TITLE
Make discover(ignore=...) work correctly

### DIFF
--- a/faust/app/base.py
+++ b/faust/app/base.py
@@ -7,7 +7,6 @@ Everything starts here.
 import asyncio
 import importlib
 import inspect
-import re
 import typing
 import warnings
 from datetime import tzinfo
@@ -608,7 +607,7 @@ class App(AppT, Service):
         for fixup in self.fixups:
             modules |= set(fixup.autodiscover_modules())
         if modules:
-            scanner = self._new_scanner(*[re.compile(pat) for pat in ignore])
+            scanner = venusian.Scanner()
             for name in modules:
                 try:
                     module = importlib.import_module(name)
@@ -617,6 +616,7 @@ class App(AppT, Service):
                         f'Unknown module {name} in App.conf.autodiscover list')
                 scanner.scan(
                     module,
+                    ignore=ignore,
                     categories=tuple(categories),
                 )
 
@@ -635,10 +635,6 @@ class App(AppT, Service):
             if self.conf.origin:
                 modules.append(self.conf.origin)
         return modules
-
-    def _new_scanner(self, *ignore: Pattern,
-                     **kwargs: Any) -> venusian.Scanner:
-        return venusian.Scanner(ignore=[pat.search for pat in ignore])
 
     def main(self) -> None:
         """Execute the :program:`faust` umbrella command using this app."""


### PR DESCRIPTION
## Description

Make discover(ignore=...) work correctly
  * venusian.Scanner().scan does not refer to self.ignore but rather the kwargs ignore https://github.com/Pylons/venusian/blob/master/venusian/__init__.py#L57
  * ignore is no longer preprocessed. This allows users to leverage the built in ignore patterns the venusian offers
