### PR TITLE
Update minimum required version of pytest

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -7,7 +7,7 @@ pytest-forked
 pytest-openfiles>=0.2.0
 pytest-random-order>=0.5.4
 pytest-xdist>=1.20
-pytest~=3.0
+pytest~=3.6
 pytz>=2018.7
 -r extras/datadog.txt
 -r extras/redis.txt


### PR DESCRIPTION
This PR updates the minimum version of the dependency on pytest to 3.6.

The unit tests use the pytest function `get_closest_marker` which was introduced in [this commit](https://github.com/pytest-dev/pytest/commit/4914135fdf45bc4fa0469f2a9d3161c5830e84fd). The function was first released with pytest-3.6.

Running the unit tests with an earlier version of pytest results in the following error:

```
    @pytest.yield_fixture()
    def freeze_time(event_loop, request):
>       marks = request.node.get_closest_marker('time')
E       AttributeError: 'Function' object has no attribute 'get_closest_marker'
```