### PR TITLE
Cleanup processor in take; Fixes #262

### DIFF
--- a/faust/streams.py
+++ b/faust/streams.py
@@ -337,6 +337,9 @@ class Stream(StreamT[T_co], Service):
                 buffer_consuming = self.loop.create_future()
                 try:
                     yield list(buffer)
+                except BaseException:
+                    self._processors.remove(add_to_buffer)
+                    raise
                 finally:
                     buffer.clear()
                     for event in events:


### PR DESCRIPTION
## Description

https://github.com/robinhood/faust/blob/5d8152d733b21401cf8d0d959cfd6f584e475c72/faust/streams.py#L337-L347

If `yield` here throws an exception, the generators `add_to_buffer` will stick around in `self._processors` and cause a deadlock as `add_to_buffer` will wait indefinitely for the buffer to be consumed (and the buffer will never be consumed because the consumer generator is dead). This causes other issue as the task will never be restarted or killed and Faust will remain in limbo.

This fix detects if there was an exception that will cause us to die, and if so, also removes `add_to_buffer` from the processors.

I'm not sure how the use `processors` may also cause deadlocks in other stream helper functions, but that may also be worth looking into.

Finally, I'm unsure how to add tests for this feature (I don't publish many Python projects), but I would be happy to add them if given a general pointer on where I should add them.

Fixes #262 