### PR TITLE
Docs: Fix Sphinx linking

### DIFF
--- a/docs/playbooks/vscelery.rst
+++ b/docs/playbooks/vscelery.rst
@@ -61,7 +61,7 @@ The Celery task above can be rewritten in Faust like this:
 Faust also support storing state with the task (see :ref:`guide-tables`),
 and it supports leader election which is useful for things such as locks.
 
-**Learn more about Faust in the** :ref:`intro` **introduction page**
+**Learn more about Faust in the** :ref:`introduction` **introduction page**
     to read more about Faust, system requirements, installation instructions,
     community resources, and more.
 


### PR DESCRIPTION
This commit changes Sphinx link from mode introduction,
https://mode.readthedocs.io/en/latest/introduction.html#intro
to faust introduction,
https://faust.readthedocs.io/en/latest/introduction.html

Verified with `make docs`.

*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://faust.readthedocs.io/en/master/contributing.html).

## Description

Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
