### PR TITLE
Make fetch_max_wait_ms configurable

### DIFF
--- a/faust/transport/drivers/aiokafka.py
+++ b/faust/transport/drivers/aiokafka.py
@@ -181,7 +181,8 @@ class AIOKafkaConsumerThread(ConsumerThread):
             auto_offset_reset=conf.consumer_auto_offset_reset,
             max_poll_records=conf.broker_max_poll_records,
             max_partition_fetch_bytes=conf.consumer_max_fetch_size,
-            fetch_max_wait_ms=1500,
+            fetch_max_wait_ms=int(conf.consumer_max_fetch_wait * 1000.0
+                if conf.consumer_max_fetch_wait else 1500),
             request_timeout_ms=int(conf.broker_request_timeout * 1000.0),
             check_crcs=conf.broker_check_crcs,
             session_timeout_ms=int(conf.broker_session_timeout * 1000.0),


### PR DESCRIPTION
## Description

Our payloads are very large and often timeout with the hardcoded default timeout of 1.5s.
Make `fetch_max_wait_ms configurable or default to 1.5s.