### PR TITLE
Allow for a user defined scheduling strategy

### DIFF
--- a/faust/app/base.py
+++ b/faust/app/base.py
@@ -32,6 +32,7 @@ from typing import (
     Type,
     Union,
     cast,
+    ClassVar
 )
 
 from mode import Seconds, Service, ServiceT, SupervisorStrategyT, want_seconds
@@ -81,6 +82,7 @@ from faust.types.transports import (
     ProducerT,
     TPorTopicSet,
     TransportT,
+    SchedulingStrategyT
 )
 from faust.types.tuples import MessageSentCallback, RecordMetadata, TP
 from faust.types.web import (
@@ -94,6 +96,8 @@ from faust.types.web import (
     Web,
 )
 from faust.types.windows import WindowT
+
+from faust.transport.utils import TopicPartitionSchedulingStrategy
 
 from ._attached import Attachments
 
@@ -390,6 +394,7 @@ class App(AppT, Service):
                  config_source: Any = None,
                  loop: asyncio.AbstractEventLoop = None,
                  beacon: NodeT = None,
+                 SchedulingStrategy: ClassVar[Type[SchedulingStrategyT]] = TopicPartitionSchedulingStrategy,
                  **options: Any) -> None:
         # This is passed to the configuration in self.conf
         self._default_options = (id, options)
@@ -428,6 +433,10 @@ class App(AppT, Service):
         # initialize fixups (automatically applied extensions,
         # such as Django integration).
         self.fixups = self._init_fixups()
+
+        # A strategy which dictates the priority of topics and partitions for incoming records.
+        # A default strategy does first round-robin over topics and then round-robin over partitions.
+        self.SchedulingStrategy = SchedulingStrategy
 
         self.boot_strategy = self.BootStrategy(self)
 
@@ -1403,6 +1412,7 @@ class App(AppT, Service):
             on_partitions_revoked=self._on_partitions_revoked,
             on_partitions_assigned=self._on_partitions_assigned,
             beacon=self.beacon,
+            SchedulingStrategy=self.SchedulingStrategy,
         )
 
     def _new_conductor(self) -> ConductorT:

--- a/faust/transport/base.py
+++ b/faust/transport/base.py
@@ -23,11 +23,13 @@ from faust.types.transports import (
     ProducerT,
     TransactionManagerT,
     TransportT,
+    SchedulingStrategyT
 )
 
 from .conductor import Conductor
 from .consumer import Consumer, Fetcher, TransactionManager
 from .producer import Producer
+from .utils import TopicPartitionSchedulingStrategy
 
 if typing.TYPE_CHECKING:  # pragma: no cover
     from faust.app import App
@@ -68,8 +70,12 @@ class Transport(TransportT):
         self.loop = loop or asyncio.get_event_loop()
 
     def create_consumer(self, callback: ConsumerCallback,
+                        SchedulingStrategy: ClassVar[Type[SchedulingStrategyT]] = TopicPartitionSchedulingStrategy,
                         **kwargs: Any) -> ConsumerT:
-        return self.Consumer(self, callback=callback, loop=self.loop, **kwargs)
+        return self.Consumer(self, callback=callback,
+                             loop=self.loop,
+                             SchedulingStrategy=SchedulingStrategy,
+                             **kwargs)
 
     def create_producer(self, **kwargs: Any) -> ProducerT:
         return self.Producer(self, **kwargs)

--- a/faust/types/transports.py
+++ b/faust/types/transports.py
@@ -21,6 +21,7 @@ from typing import (
     Type,
     Union,
     no_type_check,
+    Iterator
 )
 
 from mode import Seconds, ServiceT
@@ -446,3 +447,15 @@ class TransportT(abc.ABC):
     @abc.abstractmethod
     def create_conductor(self, **kwargs: Any) -> ConductorT:
         ...
+
+
+
+class SchedulingStrategyT:
+    @abc.abstractmethod
+    def __init__(self, records: Mapping[TP, List]) -> None:
+        ...
+
+    @abc.abstractmethod
+    def records_iterator(self) -> Iterator[Tuple[TP, Any]]:
+        ...
+


### PR DESCRIPTION
This feature allows for a user defined scheduling strategy that replaces the the default one, which is round-robin over topics (outer loop) and round-robin over partitions (inner loop). See #291. 

The following was done in this PR.
1. Create an abstract class for scheduling strategy.
2. Put the code that implements the default scheduling strategy together in a class that is separted from `Customer` and inherits from the base class above.
3. Allow for a custom scheduling strategy that is passed externally to app definition.

The code under 2. is now doing almost exactly the same as before. The only difference is the location of `self.flow_active` checks. Since I was not sure what the purpose of multiple checks is, please check that this logic still works correctly.
