### PR TITLE
Attach agent beacon to app beacon so that an agent can crash app

### DIFF
--- a/faust/agents/agent.py
+++ b/faust/agents/agent.py
@@ -220,6 +220,11 @@ class Agent(AgentT, Service):
         self.use_reply_headers = use_reply_headers
         Service.__init__(self)
 
+    def on_init_dependencies(self) -> Iterable[ServiceT]:
+        # Agent service is now a child of app.
+        self.beacon.reattach(self.app.beacon)
+        return []
+
     async def _start_one(self,
                          *,
                          index: Optional[int] = None,
@@ -596,7 +601,6 @@ class Agent(AgentT, Service):
             # can start a new one.
             await aref.crash(exc)
             self.supervisor.wakeup()
-            raise
 
     async def _slurp(self, res: ActorRefT, it: AsyncIterator) -> None:
         # this is used when the agent returns an AsyncIterator,


### PR DESCRIPTION
## Description

While debugging #301, I noticed that in order for a crash to to propagate throughout the app, a `service` will walk its graph and mark all of its children and parents as crashed. 

1. When a [mode](https://github.com/ask/mode) service begins, it adds all of its dependencies as children. However, this piece of code bypasses the `add_dependency` helper method and calls `self.children._extend`(https://github.com/ask/mode/blob/master/mode/services.py#L715) directly, which prevents that service's children from attaching itself to the parent's beacon. This causes each child to start a new tree and have no way of crashing the parent if required.

     I think this is a bug in mode, and I will submit a PR to fix that. However this alone won't fix #301 in Faust.

1. Due to the Agent's are launched in Faust (via the AgentManager's `on_start` call), they aren't direct dependencies of `faust.App`, and therefore again live in their own tree. The AgentManager doesn't consider the Agents as it's own dependency (instead it has an internal map of all agents), so instead to fix the issue in Faust, the agent itself attaches it's beacon to it's parent App. This fix allows an agent to crash the App with the `CrashingSupervisor`.

1. We remove the raise to prevent a deadlock when stopping the app. (`mode`'s `Service` also doesn't have this raise in it's `_execute_task` function.)

Currently, the `test_Agent.test_execute_task__raising` test fails, but I'm not sure how to fix it. I don't think `_execute_task` should be raising here, so maybe the test should be removed. However I'm not sure what to replace it with. It's also not clear why `Agent` will raise here, but `Service` doesn't.