### PR TITLE
added ordered client assignment to copartitioned assignor

### DIFF
--- a/docs/userguide/settings.rst
+++ b/docs/userguide/settings.rst
@@ -1252,6 +1252,21 @@ Example using the string path to a class::
 
     app = App(..., Worker='myproj.assignor.PartitionAssignor')
 
+.. setting:: ordered_client_assignment
+
+``ordered_client_assignment``
+-----------------------
+
+:type: :class:`bool`
+:default: ``False``
+
+If you set ordered_client_assignment to true the assignment in the
+CopartitionedAssignor will order the clients by broker_client_id
+before starting round robin in order to let the same client get the
+same partitions everytime a fresh partition assignment is made.
+
+StickPartitionAssignment will overrule this.
+
 .. setting:: LeaderAssignor
 
 ``LeaderAssignor``

--- a/docs/userguide/settings.rst
+++ b/docs/userguide/settings.rst
@@ -1255,7 +1255,7 @@ Example using the string path to a class::
 .. setting:: ordered_client_assignment
 
 ``ordered_client_assignment``
------------------------
+-----------------------------
 
 :type: :class:`bool`
 :default: ``False``

--- a/faust/assignor/copartitioned_assignor.py
+++ b/faust/assignor/copartitioned_assignor.py
@@ -1,10 +1,11 @@
 """Copartitioned Assignor."""
+import collections
 from itertools import cycle
 from math import ceil
 from typing import Iterable, Iterator, MutableMapping, Optional, Sequence, Set
 from mode.utils.compat import Counter
 from .client_assignment import CopartitionedAssignment
-import collections
+from faust.types.app import AppT
 
 __all__ = ['CopartitionedAssignor']
 
@@ -38,7 +39,7 @@ class CopartitionedAssignor:
     _client_assignments: MutableMapping[str, CopartitionedAssignment]
 
     def __init__(self,
-                 app,
+                 app: AppT,
                  topics: Iterable[str],
                  cluster_asgn: MutableMapping[str, CopartitionedAssignment],
                  num_partitions: int,

--- a/faust/assignor/copartitioned_assignor.py
+++ b/faust/assignor/copartitioned_assignor.py
@@ -175,7 +175,8 @@ class CopartitionedAssignor:
         client_limit = self._get_client_limit(active)
         if self.app.conf.ordered_client_assignment:
             candidates = cycle(collections.OrderedDict(
-                sorted(self._client_assignments.items(), key=lambda t: t[0])).values())
+                sorted(self._client_assignments.items(),
+                       key=lambda t: t[0])).values())
         else:
             candidates = cycle(self._client_assignments.values())
         unassigned = list(unassigned)

--- a/faust/assignor/partition_assignor.py
+++ b/faust/assignor/partition_assignor.py
@@ -208,6 +208,7 @@ class PartitionAssignor(AbstractPartitionAssignor, PartitionAssignorT):
                 # Get assignment for unique copartitioned group
                 assgn = cluster_assgn.copartitioned_assignments(topics)
                 assignor = CopartitionedAssignor(
+                    app=self.app,
                     topics=topics,
                     cluster_asgn=assgn,
                     num_partitions=num_partitions,

--- a/faust/types/settings.py
+++ b/faust/types/settings.py
@@ -346,7 +346,7 @@ class Settings(abc.ABC):
     _Topic: Type[TopicT]
     _HttpClient: Type[HttpClientT]
     _Monitor: Type[SensorT]
-    _ordered_client_assignemnt: Optional[bool] = ORDERED_CLIENT_ASSIGNMENT
+    _ordered_client_assignment: Optional[bool] = ORDERED_CLIENT_ASSIGNMENT
 
     _initializing: bool = True
     _accessed: Set[str]

--- a/t/functional/test_app.py
+++ b/t/functional/test_app.py
@@ -64,6 +64,7 @@ class test_settings:
         assert conf.stream_ack_exceptions
         assert (conf.broker_max_poll_records ==
                 settings.BROKER_MAX_POLL_RECORDS)
+        assert (ordered_client_assignment == settings.ORDERED_CLIENT_ASSIGNMENT)
 
         assert not conf.autodiscover
         assert conf.origin is None
@@ -178,6 +179,7 @@ class test_settings:
                                  worker_redirect_stdouts=False,
                                  worker_redirect_stdouts_level='DEBUG',
                                  broker_max_poll_records=1000,
+                                 ordered_client_assignment=True,
                                  timezone=pytz.timezone('US/Eastern'),
                                  **kwargs) -> App:
         livelock_soft_timeout = broker_commit_livelock_soft_timeout
@@ -226,6 +228,7 @@ class test_settings:
             web_transport=web_transport,
             worker_redirect_stdouts=worker_redirect_stdouts,
             worker_redirect_stdouts_level=worker_redirect_stdouts_level,
+            ordered_client_assignment=ordered_client_assignment,
         )
         conf = app.conf
         assert conf.id == app.conf._prepare_id(id)
@@ -274,6 +277,7 @@ class test_settings:
         assert (conf.worker_redirect_stdouts_level ==
                 worker_redirect_stdouts_level)
         assert conf.broker_max_poll_records == broker_max_poll_records
+        assert conf.ordered_client_assignment == ordered_client_assignment
         return app
 
     def test_custom_host_port_to_canonical(self,

--- a/t/functional/test_app.py
+++ b/t/functional/test_app.py
@@ -64,7 +64,8 @@ class test_settings:
         assert conf.stream_ack_exceptions
         assert (conf.broker_max_poll_records ==
                 settings.BROKER_MAX_POLL_RECORDS)
-        assert (ordered_client_assignment == settings.ORDERED_CLIENT_ASSIGNMENT)
+        assert (conf.ordered_client_assignment ==
+                settings.ORDERED_CLIENT_ASSIGNMENT)
 
         assert not conf.autodiscover
         assert conf.origin is None


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://faust.readthedocs.io/en/master/contributing.html).

## Description

If you set ordered_client_assignment to true the assignment in the CopartitionedAssignor will order the clients by broker_client_id before starting round robin in order to let the same client get the same partitions everytime a fresh partition assignment is made. This helps us a lot when we deploy because we can delete all old worker instances and ensure that the worker instance that had a partition before (and the according rocksdb status of the changelog tables) gets the same partitions again which leads to less data loaded from changelog topics because the worker already has the full state in rocksdb.