### PR TITLE
app.timer:  Use a generator to prevent timer drift

### DIFF
--- a/faust/app/base.py
+++ b/faust/app/base.py
@@ -19,6 +19,7 @@ from typing import (
     Awaitable,
     Callable,
     ContextManager,
+    Generator,
     Iterable,
     Iterator,
     List,
@@ -881,7 +882,7 @@ class App(AppT, Service):
         def _inner(fun: TaskArg) -> TaskArg:
             @wraps(fun)
             async def around_timer(*args: Any) -> None:
-                def get_next_interval():
+                def get_next_interval() -> Generator[float, None, None]:
                     start_time = time.time()
                     for counter in count(start=1):
                         yield max(start_time + counter * interval_s -


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://faust.readthedocs.io/en/master/contributing.html).

## Description

Changed the timer implementation to use a generator to calculate the amount of time to sleep until the next execution.  This prevents execution time from causing timer drift.

Fixes #318 