### PR TITLE
Fixed partition_assignor.py to not use a nullcontext span

### DIFF
--- a/faust/assignor/partition_assignor.py
+++ b/faust/assignor/partition_assignor.py
@@ -19,7 +19,6 @@ from kafka.coordinator.protocol import (
     ConsumerProtocolMemberMetadata,
 )
 from mode import get_logger
-from mode.utils.contexts import nullcontext
 from yarl import URL
 
 from faust.types.app import AppT
@@ -192,18 +191,15 @@ class PartitionAssignor(AbstractPartitionAssignor, PartitionAssignorT):
             self,
             cluster: ClusterMetadata,
             member_metadata: MemberMetadataMapping) -> MemberAssignmentMapping:
+        assignment = self._perform_assignment(cluster, member_metadata)
         if self.app.tracer:
             span = self.app.tracer.get_tracer('_faust').start_span(
                 operation_name='coordinator_assignment',
                 tags={'hostname': socket.gethostname(),
                       'cluster': cluster,
                       'member_metadata': member_metadata})
-        else:
-            span = nullcontext()
-        with span:
-            assignment = self._perform_assignment(cluster, member_metadata)
             span.set_tag('assignment', assignment)
-            return assignment
+        return assignment
 
     def _perform_assignment(
             self,

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ deps=
     linkcheck,apicheck,configcheck: -r{toxinidir}/requirements/docs.txt
     flake8,docstyle: -r{toxinidir}/requirements/dist.txt
     bandit: bandit
+passenv = http_proxy HTTP_PROXY https_proxy HTTPS_PROXY no_proxy NO_PROXY
 sitepackages = False
 recreate = False
 commands = py.test --random-order --open-files -xvv --cov=faust t/unit t/functional t/integration t/meticulous/


### PR DESCRIPTION
Fixes #320 

This patch modified partition_assignor.py so it doesn't try to use a nullcontext() as a span object.

It also updates tox.ini to pass HTTP proxy environment variables so tox
works behind a corporate firewall.

