### PR TITLE
[web][cache] Add option to include headers when building cache key

### DIFF
--- a/faust/types/web.py
+++ b/faust/types/web.py
@@ -109,6 +109,7 @@ class CacheBackendT(ServiceT):
 class CacheT(abc.ABC):
 
     timeout: Seconds
+    include_headers: bool
     key_prefix: str
     backend: Optional[Union[Type[CacheBackendT], str]]
 
@@ -123,6 +124,7 @@ class CacheT(abc.ABC):
     @abc.abstractmethod
     def view(self,
              timeout: Seconds = None,
+             include_headers: bool = False,
              key_prefix: str = None,
              **kwargs: Any) -> Callable[[Callable], Callable]:
         ...
@@ -135,6 +137,7 @@ class BlueprintT(abc.ABC):
     @abc.abstractmethod
     def cache(self,
               timeout: Seconds = None,
+              include_headers: bool = False,
               key_prefix: str = None,
               backend: Union[Type[CacheBackendT], str] = None) -> CacheT:
         ...

--- a/faust/web/base.py
+++ b/faust/web/base.py
@@ -303,6 +303,7 @@ class Request(abc.ABC):
     """HTTP Request."""
 
     method: str
+    headers: Mapping[str, str]
     url: URL
     rel_url: URL
     query_string: str

--- a/faust/web/blueprints.py
+++ b/faust/web/blueprints.py
@@ -110,11 +110,12 @@ class Blueprint(BlueprintT):
 
     def cache(self,
               timeout: Seconds = None,
+              include_headers: bool = False,
               key_prefix: str = None,
               backend: Union[Type[CacheBackendT], str] = None) -> CacheT:
         if key_prefix is None:
             key_prefix = self.name
-        return Cache(timeout, key_prefix, backend)
+        return Cache(timeout, include_headers, key_prefix, backend)
 
     def route(self,
               uri: str,

--- a/t/functional/web/test_cache.py
+++ b/t/functional/web/test_cache.py
@@ -89,16 +89,18 @@ async def test_cached_view__cannot_cache(*, app, bp, web_client, web):
 
 
 @pytest.mark.app(cache='memory://')
-def test_key_for_request(*, app):
+@pytest.mark.parametrize('include_headers', [True, False])
+def test_key_for_request(include_headers, *, app):
     _cache = blueprint.cache(timeout=DEFAULT_TIMEOUT)
     request = Mock(name='request')
     _cache.build_key = Mock(name='build_key')
-    _cache.key_for_request(request, prefix='/foo/')
+    _cache.key_for_request(
+        request, prefix='/foo/', include_headers=include_headers)
     _cache.build_key.assert_called_once_with(
         request,
         request.method,
         '/foo/',
-        [],
+        request.headers if include_headers else {},
     )
 
 


### PR DESCRIPTION
## Description

Adding functionality to include headers when creating the cache key for a request. This is useful if your endpoint does not have any parameters but is expected to behave differently based on different headers. 

An example can be when retrieving the user uuid from the JWT token passed in the authorization header for a personalized endpoint.