### PR TITLE
Fix list of strings for broker param in url

### DIFF
--- a/faust/utils/urls.py
+++ b/faust/utils/urls.py
@@ -2,10 +2,8 @@
 from typing import List, Optional, Union
 from yarl import URL
 
-__all__ = ['urllist', 'ensure_scheme']
 
-
-def urllist(arg: Union[URL, str, List[URL]], *,
+def urllist(arg: Union[URL, str, List[str], List[URL]], *,
             default_scheme: str = None) -> List[URL]:
     """Create list of URLs.
 
@@ -13,29 +11,26 @@ def urllist(arg: Union[URL, str, List[URL]], *,
     and this will convert that into a list of :class:`yarl.URL` objects.
     """
     if not arg:
-        raise ValueError('URL list argument cannot be empty')
-    if not isinstance(arg, list):
-        urls = str(arg).split(';')
-        scheme = URL(urls[0]).scheme or default_scheme
-        return [ensure_scheme(scheme, u) for u in urls]
-    else:
-        scheme = arg[0].scheme or default_scheme
-        return [ensure_scheme(scheme, u) for u in arg]
+        raise ValueError('URL argument cannot be falsy')
+
+    if isinstance(arg, URL):
+        arg = [arg]
+    elif isinstance(arg, str):
+        arg = arg.split(';')
+
+    scheme = URL(arg[0]).scheme or default_scheme
+    return [_ensure_scheme(scheme, URL(u)) for u in arg]
 
 
-def ensure_scheme(default_scheme: Optional[str], url: Union[str, URL]) -> URL:
+def _ensure_scheme(default_scheme: Optional[str], url: Union[URL]) -> URL:
     """Ensure URL has a default scheme.
 
     An URL like "localhost" will be returned with the default scheme
     added, while an URL with existing scheme is returned unmodified.
     """
-    scheme: Optional[str] = None
-    if default_scheme:
-        if isinstance(url, URL):
-            scheme = url.scheme
+    if default_scheme and not url.scheme:
+        if url.is_absolute():
+            return url.with_scheme(default_scheme)
         else:
-            _scheme, has_scheme, _ = url.partition('://')
-            scheme = _scheme if has_scheme else None
-        if not scheme:
             return URL(f'{default_scheme}://{url}')
-    return URL(url)
+    return url

--- a/t/unit/utils/test_urls.py
+++ b/t/unit/utils/test_urls.py
@@ -1,15 +1,6 @@
 import pytest
 from yarl import URL
-from faust.utils.urls import ensure_scheme, urllist
-
-
-@pytest.mark.parametrize('default,url,expected', [
-    (None, 'kafka://', URL('kafka://')),
-    ('', 'kafka://', URL('kafka://')),
-    ('http', 'localhost', URL('http://localhost')),
-])
-def test_ensure_scheme(default, url, expected):
-    assert ensure_scheme(default, url) == expected
+from faust.utils.urls import urllist
 
 
 def test_urllist_URL():
@@ -53,6 +44,13 @@ def test_urllist_strsep_no_scheme():
         URL('bar://bar.com'),
         URL('bar://example.com'),
     ]
+
+
+def test_urllist_list_of_strings():
+    assert urllist(['kafka://kafka1.example.com:9092',
+                    'kafka://kafka2.example.com:9092',
+                    ]) == [URL('kafka://kafka1.example.com:9092'),
+                           URL('kafka://kafka2.example.com:9092')]
 
 
 def test_urllist_URLs():


### PR DESCRIPTION

## Description

Fixes the `urllist` method called on the `broker` param so that https://faust.readthedocs.io/en/latest/userguide/settings.html#broker "list of strings" example actually works.

Probably could use some doctests.