### PR TITLE
Update aiohttp requirement

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,4 +1,4 @@
-aiohttp>=2.3.9,<4.0
+aiohttp>=3.5.2,<4.0
 aiohttp_cors>=0.7,<2.0
 robinhood-aiokafka>=1.0.3,<1.1
 click>=6.7,<7.0


### PR DESCRIPTION
## Description

It will fail to import `BaseSite` from `aiohttp.web` with `aiohttp<3.5.0`.
https://github.com/robinhood/faust/blob/e73ec2ccbb01de61babb475326ecc8b1c2407343/faust/web/drivers/aiohttp.py#L15-L23

Ref https://github.com/aio-libs/aiohttp/commit/593a3ac8dd5266e875d727aeaa820191d493d623.
