### PR TITLE
[WIP] Provide information on Model field types to codecs

### DIFF
--- a/faust/models/base.py
+++ b/faust/models/base.py
@@ -401,8 +401,7 @@ class Model(ModelT):
 
     def dumps(self, *, serializer: CodecArg = None) -> bytes:
         """Serialize object to the target serialization format."""
-        return dumps(serializer or self._options.serializer,
-                     self.to_representation())
+        return dumps(serializer or self._options.serializer, self)
 
     def __repr__(self) -> str:
         return f'<{type(self).__name__}: {self._humanize()}>'

--- a/faust/models/record.py
+++ b/faust/models/record.py
@@ -8,6 +8,7 @@ from typing import (
     Dict,
     FrozenSet,
     Iterable,
+    Iterator,
     List,
     Mapping,
     Optional,
@@ -203,6 +204,15 @@ class Record(Model, abstract=True):
         >>> LogEvent.severity
         >>> <FieldDescriptor: LogEvent.severity (str)>
     """
+
+    def __getitem__(self, k: str) -> Any:
+        return self.to_representation()[k]
+
+    def __len__(self) -> int:
+        return len(self.to_representation())
+
+    def __iter__(self) -> Iterator[Any]:
+        return iter(self.to_representation())
 
     @classmethod
     def _contribute_to_options(cls, options: ModelOptions) -> None:

--- a/t/functional/test_models.py
+++ b/t/functional/test_models.py
@@ -1047,3 +1047,17 @@ def test_maybe_model():
 
     x1 = X(10, 20)
     assert maybe_model(json.loads(x1.dumps(serializer='json'))) == x1
+
+
+def test_record_provides_mapping_interface():
+    class X(Record):
+        x: int
+        y: int
+
+    p = X(4, 2)
+
+    representation = p.to_representation()
+    assert len(p) == len(representation)
+    assert set(iter(p)) == representation.keys()
+    assert p['x'] == p.x
+    assert p['y'] == p.y


### PR DESCRIPTION
## Description
Currently, Codecs receive the data provided by `Model.to_representation()` to serialize data. The representation of a Record is a dictionary containing the record data. The conversion of Records to a dictionary drops all information on the Model types preventing codecs from querying the model's type information (as suggested in #315).

This PR passes the Model instances itself of `dumps` instead of the model representations. A Record implements the methods of `Mapping`. A hypothetical `Array` model would implement `Sequence`.

### Issues
As it is now, this PR would break code that implements a custom codec and mutates the dict passed to `dumps`. Should we implement `MutableMapping` instead of just `Mapping` to improve backwards compatibilty?

Making `Record` inherit `Mapping` will cause a clash of the metaclass attribute `namespace`, which is an argument to both `Model` and a superclass of `Mapping`. Renaming `Model.namespace` still does not solve the issue which is why I gave up trying to inherit `Mapping` in `Record`. I simply implemented the corresponding methods.