### PR TITLE
Fix the `producer_max_batch_size` parameter description

### DIFF
--- a/docs/userguide/settings.rst
+++ b/docs/userguide/settings.rst
@@ -861,7 +861,7 @@ Should rarely have to change this.
 :type: :class:`int`
 :default: 16384
 
-Max number of records in each producer batch.
+Max size of each producer batch, in bytes.
 
 .. setting:: producer_max_request_size
 


### PR DESCRIPTION
## Description
By investigating about the `producer_max_batch_size`, I noticed that its description seems incorrect.

Looking at how the parameter is used, it is the size in bytes of the batch, not the number of records in the batch. For instance https://github.com/robinhood/aiokafka/blob/master/aiokafka/record/legacy_records.py#L311
