### PR TITLE
Fixes bug where sensor index should display when :setting:`debug`

### DIFF
--- a/faust/web/base.py
+++ b/faust/web/base.py
@@ -43,6 +43,9 @@ _BPList = Iterable[Tuple[str, SymbolArg[Type[BlueprintT]]]]
 DEFAULT_BLUEPRINTS: _BPList = [
     ('/router', 'faust.web.apps.router:blueprint'),
     ('/table', 'faust.web.apps.tables.blueprint'),
+]
+
+PRODUCTION_BLUEPRINTS: _BPList = [
     ('', 'faust.web.apps.production_index:blueprint'),
 ]
 
@@ -159,6 +162,7 @@ class Web(Service):
     """Web server and HTTP interface."""
 
     default_blueprints: ClassVar[_BPList] = DEFAULT_BLUEPRINTS  # noqa: E704
+    production_blueprints: ClassVar[_BPList] = PRODUCTION_BLUEPRINTS
     debug_blueprints: ClassVar[_BPList] = DEBUG_BLUEPRINTS
 
     app: AppT
@@ -180,7 +184,9 @@ class Web(Service):
         self.reverse_names = {}
         blueprints = list(self.default_blueprints)
         if self.app.conf.debug:
-            blueprints += self.debug_blueprints
+            blueprints.extend(self.debug_blueprints)
+        else:
+            blueprints.extend(self.production_blueprints)
         self.blueprints = BlueprintManager(blueprints)
         Service.__init__(self, **kwargs)
 

--- a/t/unit/web/test_base.py
+++ b/t/unit/web/test_base.py
@@ -4,6 +4,7 @@ from faust.web.base import (
     BlueprintManager,
     DEBUG_BLUEPRINTS,
     DEFAULT_BLUEPRINTS,
+    PRODUCTION_BLUEPRINTS,
     Web,
 )
 from mode.utils.mocks import Mock, patch
@@ -98,7 +99,8 @@ class test_Web:
 
     def test_production_blueprints(self, *, web):
         assert not web.app.conf.debug
-        assert web.blueprints._enabled == DEFAULT_BLUEPRINTS
+        assert web.blueprints._enabled == (
+            DEFAULT_BLUEPRINTS + PRODUCTION_BLUEPRINTS)
 
     def test_url_for(self, *, web):
         web.reverse_names['test'] = '/foo/{bar}/'


### PR DESCRIPTION
## Description
Sensor index should display when debug, right?

By put default 'production_index' in a separate _BPList, it is easy to make app display or not display sensor index depends on app debug setting.