### PR TITLE
Upgrade click requirement to 7.x

### DIFF
--- a/faust/cli/base.py
+++ b/faust/cli/base.py
@@ -168,7 +168,7 @@ now_builtin_worker_options: OptionSequence = [
         '--loglevel', '-l',
         state_key='loglevel',
         default=DEFAULT_LOGLEVEL,
-        type=params.CaseInsensitiveChoice(LOGLEVELS),
+        type=click.Choice(LOGLEVELS, case_sensitive=False),
         help='Logging level to use.',
     ),
     compat_option(

--- a/faust/cli/params.py
+++ b/faust/cli/params.py
@@ -1,5 +1,5 @@
 """Python :pypi:`click` parameter types."""
-from typing import Any, Iterable, Optional
+from typing import Optional
 import click
 from click.types import ParamType, StringParamType
 from yarl import URL
@@ -7,7 +7,6 @@ from yarl import URL
 __all__ = [
     'WritableDirectory',
     'WritableFilePath',
-    'CaseInsensitiveChoice',
     'TCPPort',
     'URLParam',
 ]
@@ -28,22 +27,6 @@ WritableFilePath = click.Path(
     writable=True,      # and read/write access.
     readable=True,      #
 )
-
-
-class CaseInsensitiveChoice(click.Choice):
-    """Case-insensitive version of :class:`click.Choice`."""
-
-    def __init__(self, choices: Iterable[Any]) -> None:
-        self.choices = [str(val).lower() for val in choices]
-
-    def convert(self,
-                value: str,
-                param: Optional[click.Parameter],
-                ctx: Optional[click.Context]) -> Any:
-        """Convert string to case-insensitive choice."""
-        if value.lower() in self.choices:
-            return value
-        return super().convert(value, param, ctx)
 
 
 class TCPPort(click.IntRange):

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,7 +1,7 @@
 aiohttp>=3.5.2,<4.0
 aiohttp_cors>=0.7,<2.0
 robinhood-aiokafka>=1.0.3,<1.1
-click>=6.7,<7.0
+click>=7.0,<8.0
 colorclass>=2.2,<3.0
 mode>=4.0,<4.1
 opentracing>=1.3.0,<2.0.0

--- a/t/unit/cli/test_params.py
+++ b/t/unit/cli/test_params.py
@@ -1,23 +1,7 @@
 import click.exceptions
 import pytest
 from yarl import URL
-from faust.cli.params import CaseInsensitiveChoice, TCPPort, URLParam
-
-
-def test_CaseInsensitiveChoice():
-    choices = CaseInsensitiveChoice([
-        'FOO',
-        'BAR',
-        'baz',
-    ])
-
-    assert choices.convert('FOO', None, None) == 'FOO'
-    assert choices.convert('foo', None, None) == 'foo'
-    assert choices.convert('Foo', None, None) == 'Foo'
-    assert choices.convert('BAZ', None, None) == 'BAZ'
-
-    with pytest.raises(click.exceptions.BadParameter):
-        choices.convert('xuz', None, None)
+from faust.cli.params import TCPPort, URLParam
 
 
 def test_TCPPort():


### PR DESCRIPTION
## Description

The only problem that appeared was that Click introduced case insensitive choices so there were a conflict with custom implementation in Faust. See https://github.com/sirosen/click/commit/138a6e3ad1dbe657e09717bc05ebfbc535f4770d.