### PR TITLE
Docs: syncronous app signals

### DIFF
--- a/docs/userguide/application.rst
+++ b/docs/userguide/application.rst
@@ -822,6 +822,7 @@ Signals are an implementation of the `Observer`_  design pattern.
 
 :sender: :class:`faust.App`
 :arguments: ``key, value, partition, timestamp, headers``
+:synchronous: This is a synchronous signal (do not use :keyword:`async def`).
 
 The ``on_produce_message`` signal as a synchronous signal called before
 producing messages.


### PR DESCRIPTION
Add syncronous label to `on_produce_message` app signal

*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://faust.readthedocs.io/en/master/contributing.html).

## Description

Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
