### PR TITLE
Add missing field declaration in Cython ConductorHandler

### DIFF
--- a/faust/transport/_cython/conductor.pyx
+++ b/faust/transport/_cython/conductor.pyx
@@ -15,6 +15,7 @@ cdef class ConductorHandler:
         object on_topic_buffer_full
         object acquire_flow_control
         object consumer
+        object wait_until_producer_ebb
 
     def __init__(self, object conductor, object tp, object channels):
         self.conductor = conductor


### PR DESCRIPTION
## Description

Add a missing `wait_until_producer_ebb` field to the Cython implementation of the ConductorHandler class. This patch Fixes #388.
