### PR TITLE
Bump Versions to 1.7.4

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@
 
 |build-status| |coverage| |license| |wheel| |pyversion| |pyimp|
 
-:Version: 1.7.3
+:Version: 1.7.4
 :Web: http://faust.readthedocs.io/
 :Download: http://pypi.org/project/faust
 :Source: http://github.com/robinhood/faust

--- a/docs/includes/tags.txt
+++ b/docs/includes/tags.txt
@@ -1,4 +1,4 @@
-:Version: 1.7.3
+:Version: 1.7.4
 :Web: http://faust.readthedocs.io/
 :Download: http://pypi.org/project/faust
 :Source: http://github.com/robinhood/faust

--- a/faust/__init__.py
+++ b/faust/__init__.py
@@ -24,7 +24,7 @@ import typing
 
 from typing import Any, Mapping, NamedTuple, Optional, Sequence, Tuple
 
-__version__ = '1.7.3'
+__version__ = '1.7.4'
 __author__ = 'Robinhood Markets, Inc.'
 __contact__ = 'contact@fauststream.com'
 __homepage__ = 'http://faust.readthedocs.io/'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.7.3
+current_version = 1.7.4
 commit = true
 tag = true
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?P<releaselevel>[a-z]+)?


### PR DESCRIPTION
## Description
While starting a recent side project using faust, I pulled the 1.7.3 build of faust and ran an example from the docs and ran into the following issue as resolved in https://github.com/robinhood/faust/pull/389. 

This PR simply updates the various version settings to reflect what is currently in pypi and hopefully will help save others some clicks on google.
