### PR TITLE
clear _recovery_started event of table manager on recovery completion

### DIFF
--- a/faust/tables/recovery.py
+++ b/faust/tables/recovery.py
@@ -245,6 +245,7 @@ class Recovery(Service):
         await app._fetcher.maybe_start()
         self.tables.on_actives_ready()
         self.tables.on_standbys_ready()
+        self.tables._recovery_started.clear()
         app.on_rebalance_end()
         self.log.info('Worker ready')
 
@@ -474,6 +475,7 @@ class Recovery(Service):
         self.tables.on_actives_ready()
         if not self.app.assignor.assigned_standbys():
             self.tables.on_standbys_ready()
+        self.tables._recovery_started.clear()
         self.app.on_rebalance_end()
         self.log.info('Worker ready')
 


### PR DESCRIPTION
This flag is set as soon as the rebalance is initiated causing recovery
to trigger. However it is never clear-ed

*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://faust.readthedocs.io/en/master/contributing.html).

## Description

Please describe your pull request.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
I am not really sure if this is a bug or a feature because I do not know what is the expected behavior
