### PR TITLE
Potential fix for Optional fields coercion (#393)

### DIFF
--- a/faust/models/record.py
+++ b/faust/models/record.py
@@ -17,6 +17,7 @@ from typing import (
     cast,
 )
 
+import typing_inspect
 from mode.utils.objects import (
     annotations,
     guess_polymorphic_type,
@@ -177,6 +178,16 @@ def _maybe_to_representation(val: ModelT = None) -> Optional[Any]:
     return val.to_representation() if val is not None else None
 
 
+def _is_of_type(value, typ):
+    if typing_inspect.is_union_type(typ):
+        return any(
+            _is_of_type(value, subtype)
+            for subtype in typing_inspect.get_args(typ)
+        )
+    else:
+        return isinstance(value, typ)
+
+
 class Record(Model, abstract=True):
     """Describes a model type that is a record (Mapping).
 
@@ -317,7 +328,7 @@ class Record(Model, abstract=True):
                            value: Any) -> Any:
         if value is None:
             return None
-        if isinstance(value, typ):
+        if _is_of_type(value, typ):
             return value
         return coerce(value)
 

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -10,3 +10,4 @@ venusian>=1.1,<2.0
 yarl>=1.0,<2.0
 croniter>=0.3.16
 mypy_extensions
+typing_inspect==0.4.0

--- a/t/functional/test_models.py
+++ b/t/functional/test_models.py
@@ -1057,6 +1057,15 @@ def test_optional_modelfield():
     assert isinstance(loads.x, X)
 
 
+def test_optional_modelfield_with_coercion():
+    class X(Record, coercions={str: str}):
+        y: Optional[str]
+
+    x = X(y='test')
+
+    assert x.y == 'test'
+
+
 @pytest.mark.parametrize('flag,expected_default', [
     ('isodates', False),
     ('include_metadata', True),


### PR DESCRIPTION
Potential fix for #393 

`Optional[type]` fields are transformed into `Union[type, None]` when the Record class is prepared by Faust. 

When the field value is coerced, `isinstance` is used to check if the value is already of the correct type. But `isinstance(something, Union[type1, type2])` raises `TypeError: Subscripted generics cannot be used with class and instance checks`.

This PR tries to fix this by checking the types of the union one by one, recursively.