### PR TITLE
Contributing.rst steps and removal of sphinx_autodoc_annotation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import os
 import sys
 from contextlib import suppress
 from sphinx_celery import conf
@@ -104,9 +103,6 @@ pygments_style = 'monokai'
 # This option is deprecated and raises an error.
 with suppress(NameError):
     del(html_use_smartypants)  # noqa
-
-if not os.environ.get('APICHECK'):
-    extensions.append('sphinx_autodoc_annotation')
 
 napoleon_use_keyword = True
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -524,7 +524,6 @@ reference please execute:
 .. sourcecode:: console
 
     $ make apicheck
-    $ make indexcheck
 
 If files are missing you can add them by copying an existing reference file.
 

--- a/requirements/docs-plugins.txt
+++ b/requirements/docs-plugins.txt
@@ -1,3 +1,2 @@
 alabaster
-sphinx_autodoc_annotation
 sphinx_celery>=1.4.8,<2.0


### PR DESCRIPTION
Hi.

First, I want to say thank you for such a great job. I have learned a lot from reading through the source code.
This is my first ever pull request, so I am sorry if there are any glaring mistakes. 

I tried going through the steps of the [contributing guide](https://faust.readthedocs.io/en/latest/contributing.html#id21), and I encountered some problems which I fixed in the following commits:

1. Running `make indexcheck` does not exist in the makefile
2. Running `make configcheck` fails because of `Warning, treated as error:
directive 'autofunction' is already registered, it will be overridden
make: *** [Makefile:234: configcheck] Error 2`

Side note, build were failing on the following tests:
         - t/unit/tables/test_base.py:79 test_Collection.test_info
         - t/unit/tables/test_base.py:196 test_Collection.test__verify_source_topic_partitions[3-6-True]
         - t/unit/tables/test_base.py:196 test_Collection.test__verify_source_topic_partitions[6-3-True]

I hope to be able to contribute more in the future
Best regards
Espen