### PR TITLE
Docs: fix usage example of custom serializer

### DIFF
--- a/docs/userguide/models.rst
+++ b/docs/userguide/models.rst
@@ -41,7 +41,7 @@ to ``.dumps``:
 
 .. sourcecode:: pycon
 
-    >>> Point(x=10, y=100).dumps('pickle')  # pickle + Base64
+    >>> Point(x=10, y=100).dumps(serializer='pickle')  # pickle + Base64
     b'gAN9cQAoWAEAAAB4cQFLClgBAAAAeXECS2RYBwAAAF9fZmF1c3RxA31xBFg
     CAAAAbnNxBVgOAAAAX19tYWluX18uUG9pbnRxBnN1Lg=='
 


### PR DESCRIPTION
Serializer can't be passed as positional argument. An exception `TypeError: dumps() takes 1 positional argument but 2 were given` is raised otherwise.
