### PR TITLE
Fix type mismatch on aiokafka timestamp_ms

### DIFF
--- a/faust/transport/drivers/aiokafka.py
+++ b/faust/transport/drivers/aiokafka.py
@@ -677,7 +677,7 @@ class Producer(base.Producer):
         )
         if headers is not None and not self.allow_headers:
             headers = None
-        timestamp_ms = timestamp * 1000.0 if timestamp else timestamp
+        timestamp_ms = int(timestamp * 1000.0) if timestamp else timestamp
         try:
             return cast(Awaitable[RecordMetadata], await producer.send(
                 topic, value,


### PR DESCRIPTION
aiokafka expects to receive timestamps of type int; see https://github.com/aio-libs/aiokafka/blob/master/aiokafka/record/default_records.py#L410. Update driver to convert timestamp_ms from float to int.

*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://faust.readthedocs.io/en/master/contributing.html).

## Description

Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
