### PR TITLE
Add missing `_skipped_value` attribute in Cython stream class

### DIFF
--- a/faust/_cython/streams.pyx
+++ b/faust/_cython/streams.pyx
@@ -31,6 +31,7 @@ cdef class StreamIterator:
         object app
         object topics
         object acks_enabled_for
+        object _skipped_value
 
     def __init__(self, object stream):
         self.stream = stream


### PR DESCRIPTION
Fixes a regression in 1.8.0.