### PR TITLE
Bugfix / Remove Wiki Link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -540,13 +540,6 @@ Bug tracker
 If you have any suggestions, bug reports, or annoyances please report them
 to our issue tracker at https://github.com/robinhood/faust/issues/
 
-.. _wiki:
-
-Wiki
-----
-
-https://wiki.github.com/robinhood/faust/
-
 .. _license:
 
 License

--- a/docs/includes/resources.txt
+++ b/docs/includes/resources.txt
@@ -33,13 +33,6 @@ Bug tracker
 If you have any suggestions, bug reports, or annoyances please report them
 to our issue tracker at https://github.com/robinhood/faust/issues/
 
-.. _wiki:
-
-Wiki
-----
-
-https://wiki.github.com/robinhood/faust/
-
 .. _license:
 
 License


### PR DESCRIPTION
## Description
- Wiki appears to be no longer used so link is a dead end, removed

This closes #405
