### PR TITLE
Fix for acking tombstone messages

### DIFF
--- a/faust/streams.py
+++ b/faust/streams.py
@@ -843,7 +843,7 @@ class Stream(StreamT[T_co], Service):
                 # wait for next message
                 value: Any = None
                 # we iterate until on_merge gives value.
-                while value is None:
+                while value is None and event is None:
                     await sleep(0, loop=loop)
                     # get message from channel
                     # This inlines ThrowableQueue.get for performance:


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://faust.readthedocs.io/en/master/contributing.html).

## Description

This fixes the issue of not acking tombstone messages on a topic processed by the agent
https://github.com/robinhood/faust/issues/439

