### PR TITLE
Partition number may be 0

### DIFF
--- a/faust/tables/base.py
+++ b/faust/tables/base.py
@@ -276,10 +276,7 @@ class Collection(Service, CollectionT):
 
     def partition_for_key(self, key: Any) -> int:
         if self.use_partitioner:
-            partition = self.app.consumer.key_partition(
-                self.changelog_topic_name, key, None)
-            assert partition is not None
-            return partition
+            return None
         else:
             event = current_event()
             if event is None:

--- a/faust/tables/base.py
+++ b/faust/tables/base.py
@@ -278,7 +278,7 @@ class Collection(Service, CollectionT):
         if self.use_partitioner:
             partition = self.app.consumer.key_partition(
                 self.changelog_topic_name, key, None)
-            assert partition
+            assert partition is not None
             return partition
         else:
             event = current_event()

--- a/t/unit/tables/test_base.py
+++ b/t/unit/tables/test_base.py
@@ -482,11 +482,7 @@ class test_Collection:
         assert table._repr_info() == table.name
 
     def test_partition_for_key__partitioner(self, *, table, app):
-        consumer = app.consumer = Mock(name='consumer')
         table.use_partitioner = True
 
-        partition = consumer.key_partition.return_value
+        partition = None
         assert table.partition_for_key('k') is partition
-
-        consumer.key_partition.assert_called_once_with(
-            table.changelog_topic_name, 'k', None)


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://faust.readthedocs.io/en/master/contributing.html).

## Description

The partition number returned by the key_partion function may be 0.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
