### PR TITLE
KeyError: 'search' when calling views with SEARCH method (Fixes #460)

### DIFF
--- a/faust/web/views.py
+++ b/faust/web/views.py
@@ -64,6 +64,7 @@ class View:
             'delete': self.delete,
             'put': self.put,
             'options': self.options,
+            'search': self.search,
         }
         self.__post_init__()
 
@@ -161,6 +162,11 @@ class View:
     async def options(self, request: Request, **kwargs: Any) -> Any:
         """Override ``options`` to define the HTTP OPTIONS handler."""
         raise exceptions.MethodNotAllowed('Method OPTIONS not allowed.')
+
+    @no_type_check  # subclasses change signature based on route match_info
+    async def search(self, request: Request, **kwargs: Any) -> Any:
+        """Override ``search`` to define the HTTP SEARCH handler."""
+        raise exceptions.MethodNotAllowed('Method SEARCH not allowed.')
 
     def text(self, value: str, *,
              content_type: str = None,

--- a/t/unit/web/test_views.py
+++ b/t/unit/web/test_views.py
@@ -37,11 +37,12 @@ class test_View:
             'delete': view.delete,
             'put': view.put,
             'options': view.options,
+            'search': view.search,
         }
 
     @pytest.mark.parametrize('method', [
-        'GET', 'POST', 'PATCH', 'DELETE', 'PUT', 'OPTIONS',
-        'get', 'post', 'patch', 'delete', 'put', 'options',
+        'GET', 'POST', 'PATCH', 'DELETE', 'PUT', 'OPTIONS', 'SEARCH',
+        'get', 'post', 'patch', 'delete', 'put', 'options', 'search',
     ])
     @pytest.mark.asyncio
     async def test_dispatch(self, method, *, view):
@@ -102,6 +103,11 @@ class test_View:
     async def test_interface_options(self, *, view):
         with pytest.raises(MethodNotAllowed):
             await view.options(Mock(name='request', autospec=Request))
+
+    @pytest.mark.asyncio
+    async def test_interface_search(self, *, view):
+        with pytest.raises(MethodNotAllowed):
+            await view.search(Mock(name='request', autospec=Request))
 
     def test_text(self, *, view, web):
         response = view.text(


### PR DESCRIPTION
## Description

Fix for #460 