### PR TITLE
Added ability to iterate through all keys in a global table

### DIFF
--- a/faust/app/base.py
+++ b/faust/app/base.py
@@ -1147,6 +1147,7 @@ class App(AppT, Service):
                 # we want to apply standby changes
                 # as they come min (using 1 buffer size).
                 standby_buffer_size=1,
+                is_global=True,
                 help=help,
                 **kwargs))
         return gtable.using_window(window) if window else gtable

--- a/faust/stores/rocksdb.py
+++ b/faust/stores/rocksdb.py
@@ -28,7 +28,6 @@ from yarl import URL
 
 from faust.exceptions import ImproperlyConfigured
 from faust.streams import current_event
-from faust.tables import GlobalTable
 from faust.types import AppT, CollectionT, EventT, TP
 from faust.utils import platforms
 

--- a/faust/stores/rocksdb.py
+++ b/faust/stores/rocksdb.py
@@ -390,12 +390,11 @@ class Store(base.SerializedStore):
     def _dbs_for_actives(self) -> Iterator[DB]:
         actives = self.app.assignor.assigned_actives()
         topic = self.table._changelog_topic_name()
-        is_global_table = isinstance(self.table, GlobalTable)
         for partition, db in self._dbs.items():
             tp = TP(topic=topic, partition=partition)
             # for global tables, keys from all
             # partitions are available.
-            if tp in actives or is_global_table:
+            if tp in actives or self.table.is_global:
                 yield db
 
     def _size(self) -> int:

--- a/faust/stores/rocksdb.py
+++ b/faust/stores/rocksdb.py
@@ -28,6 +28,7 @@ from yarl import URL
 
 from faust.exceptions import ImproperlyConfigured
 from faust.streams import current_event
+from faust.tables import GlobalTable
 from faust.types import AppT, CollectionT, EventT, TP
 from faust.utils import platforms
 
@@ -389,9 +390,12 @@ class Store(base.SerializedStore):
     def _dbs_for_actives(self) -> Iterator[DB]:
         actives = self.app.assignor.assigned_actives()
         topic = self.table._changelog_topic_name()
+        is_global_table = isinstance(self.table, GlobalTable)
         for partition, db in self._dbs.items():
             tp = TP(topic=topic, partition=partition)
-            if tp in actives:
+            # for global tables, keys from all
+            # partitions are available.
+            if tp in actives or is_global_table:
                 yield db
 
     def _size(self) -> int:

--- a/faust/tables/__init__.py
+++ b/faust/tables/__init__.py
@@ -1,11 +1,14 @@
 """Tables: Distributed object K/V-store."""
 from .base import Collection, CollectionT
+from .globaltable import GlobalTable, GlobalTableT
 from .manager import TableManager, TableManagerT
 from .table import Table, TableT
 
 __all__ = [
     'Collection',
     'CollectionT',
+    'GlobalTable',
+    'GlobalTableT',
     'TableManager',
     'TableManagerT',
     'Table',

--- a/faust/tables/base.py
+++ b/faust/tables/base.py
@@ -121,6 +121,7 @@ class Collection(Service, CollectionT):
                  options: Mapping[str, Any] = None,
                  use_partitioner: bool = False,
                  on_window_close: WindowCloseCallback = None,
+                 is_global: bool = False,
                  **kwargs: Any) -> None:
         Service.__init__(self, **kwargs)
         self.app = app
@@ -141,6 +142,7 @@ class Collection(Service, CollectionT):
         self.use_partitioner = use_partitioner
         self._on_window_close = on_window_close
         self.last_closed_window = 0.0
+        self.is_global = is_global
         assert self.recovery_buffer_size > 0 and self.standby_buffer_size > 0
 
         self.options = options

--- a/t/unit/stores/test_rocksdb.py
+++ b/t/unit/stores/test_rocksdb.py
@@ -433,7 +433,13 @@ class test_Store:
             3: self.new_db('db3'),
         }
 
+        # Normal Table
+        table.is_global = False
         assert list(store._dbs_for_actives()) == [dbs[1], dbs[2]]
+
+        # Global Table
+        table.is_global = True
+        assert list(store._dbs_for_actives()) == [dbs[1], dbs[2], dbs[3]]
 
     def test__size(self, *, store):
         dbs = self._setup_keys(


### PR DESCRIPTION
## Description
Fixes #451.
Added the ability to iterate through all keys and values for a global table, as opposed to just the keys belonging to the active partition of the table.

Ran py.test: 1814 tests passed, 2 warnings: 
1. DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
2. UserWarning: Using settings.DEBUG leads to a memory leak, never use this setting in production environments!