### PR TITLE
Fixed Global Tables

### DIFF
--- a/faust/tables/recovery.py
+++ b/faust/tables/recovery.py
@@ -17,7 +17,6 @@ from faust.types.tables import CollectionT, TableManagerT
 from faust.types.transports import ConsumerT
 from faust.utils import terminal
 from faust.utils.tracing import finish_span, traced_from_parent_span
-from faust.tables.globaltable import GlobalTable
 
 if typing.TYPE_CHECKING:
     from .manager import TableManager as _TableManager
@@ -163,17 +162,6 @@ class Recovery(Service):
         self.standbys_for_table[table].add(tp)
         self._add(table, tp, self.standby_offsets)
 
-    def add_standbys_for_global_table(self,
-                                      gtable: CollectionT,
-                                      active_topic: TP,
-                                      topics: Set[TP]) -> None:
-        """Add standby topics for global table."""
-        for tp in topics:
-            table = self.tables._changelogs.get(tp.topic)
-            if table is gtable and tp != active_topic:
-                # No need to add table's own topic.
-                self.add_standby(gtable, tp)
-
     def _add(self, table: CollectionT, tp: TP, offsets: Counter[TP]) -> None:
         self.tp_to_table[tp] = table
         persisted_offset = table.persisted_offset(tp)
@@ -219,9 +207,6 @@ class Recovery(Service):
             table = self.tables._changelogs.get(tp.topic)
             if table is not None:
                 self.add_active(table, tp)
-                if isinstance(table, GlobalTable):
-                    self.add_standbys_for_global_table(
-                        table, tp, assigned_actives)
 
         active_offsets = {
             tp: offset


### PR DESCRIPTION
## Description

Fixes #475 

Added standbys of global table's changelog topics to all workers. If that worker has an active partition, every partition but that gets added as standby for that worker.

Ran pytest: 1814 passed
Warnings:
```
1. DeprecationWarning:  the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
2. PytestUnknownMarkWarning: Unknown pytest.mark.allow_lingering_tasks, pytest.mark.http_session, pytest.mark.conf, pytest.mark.app
3. UserWarning: Using settings.DEBUG leads to a memory leak, never use this setting in production environments!
```