### PR TITLE
enable "use_partitioner" support for tables with SerializedStore:

### DIFF
--- a/faust/stores/base.py
+++ b/faust/stores/base.py
@@ -149,7 +149,8 @@ class SerializedStore(Store[KT, VT]):
     @abc.abstractmethod
     def _set(self,
              key: bytes,
-             value: Optional[bytes]) -> None:  # pragma: no cover
+             value: Optional[bytes],
+             partition: Optional[int]) -> None:  # pragma: no cover
         ...
 
     @abc.abstractmethod
@@ -194,7 +195,7 @@ class SerializedStore(Store[KT, VT]):
                 self._del(key)
             else:
                 # keys/values are already JSON serialized in the message
-                self._set(key, value)
+                self._set(key, value, event.message.partition)
 
     def __getitem__(self, key: KT) -> VT:
         value = self._get(self._encode_key(key))
@@ -203,7 +204,8 @@ class SerializedStore(Store[KT, VT]):
         return self._decode_value(value)
 
     def __setitem__(self, key: KT, value: VT) -> None:
-        return self._set(self._encode_key(key), self._encode_value(value))
+        return self._set(self._encode_key(key), self._encode_value(value),
+                         self.table.partition_for_key(key))
 
     def __delitem__(self, key: KT) -> None:
         return self._del(self._encode_key(key))

--- a/faust/stores/rocksdb.py
+++ b/faust/stores/rocksdb.py
@@ -27,7 +27,6 @@ from mode.utils.collections import LRUCache
 from yarl import URL
 
 from faust.exceptions import ImproperlyConfigured
-from faust.streams import current_event
 from faust.types import AppT, CollectionT, EventT, TP
 from faust.utils import platforms
 
@@ -257,10 +256,9 @@ class Store(base.SerializedStore):
         for tp, offset in tp_offsets.items():
             self.set_persisted_offset(tp, offset)
 
-    def _set(self, key: bytes, value: Optional[bytes]) -> None:
-        event = current_event()
-        assert event is not None
-        partition = event.message.partition
+    def _set(self, key: bytes, value: Optional[bytes],
+             partition: Optional[int]) -> None:
+        assert partition is not None
         db = self._db_for_partition(partition)
         self._key_index[key] = partition
         db.put(key, value)

--- a/faust/tables/base.py
+++ b/faust/tables/base.py
@@ -78,6 +78,7 @@ class Collection(Service, CollectionT):
         Tuple[int, float], MutableSet[Tuple[Any, WindowRange]]]
     _partition_timestamps: MutableMapping[int, List[float]]
     _partition_latest_timestamp: MutableMapping[int, float]
+    _key_partition_map: MutableMapping[Any, int]
     _recover_callbacks: MutableSet[RecoverCallback]
     _data: Optional[StoreT] = None
     _changelog_compacting: Optional[bool] = True

--- a/faust/tables/table.py
+++ b/faust/tables/table.py
@@ -74,6 +74,7 @@ class Table(TableT[KT, VT], Collection):
         # is in fut.partition
         partition = fut.message.partition
         assert partition is not None
+        self.set_partition_for_key(key, partition)
         self._maybe_set_key_ttl(key, partition)
         self._sensor_on_set(self, key, value)
 

--- a/t/unit/stores/test_base.py
+++ b/t/unit/stores/test_base.py
@@ -94,7 +94,7 @@ class MySerializedStore(SerializedStore):
     def _get(self, key):
         return self.keep.get(key)
 
-    def _set(self, key, value):
+    def _set(self, key, value, partition):
         self.keep[key] = value
 
     def _del(self, key):

--- a/t/unit/stores/test_rocksdb.py
+++ b/t/unit/stores/test_rocksdb.py
@@ -208,16 +208,10 @@ class test_Store:
             call(TP4, 4005),
         ])
 
-    @pytest.yield_fixture()
-    def current_event(self):
-        with patch('faust.stores.rocksdb.current_event') as current_event:
-            yield current_event.return_value
-
-    def test__set(self, *, store, db_for_partition, current_event):
-        store._set(b'key', b'value')
-        db_for_partition.assert_called_once_with(
-            current_event.message.partition)
-        assert store._key_index[b'key'] == current_event.message.partition
+    def test__set(self, *, store, db_for_partition):
+        partition = 1
+        store._set(b'key', b'value', partition)
+        assert store._key_index[b'key'] == partition
         db_for_partition.return_value.put.assert_called_once_with(
             b'key', b'value',
         )


### PR DESCRIPTION
- remove dependency to current_event in rocksdb store
- SerializedStore now utilizes the partition_for_key function of the
  parent table to get the partition
- Collections: In case of use_partitioner is set, the underlying channel
  calculates the partition. Therefore, the collection has to cache the
  key->partition mapping in memory. 


I do not really like the key-partition mapping in Collection. Unfortunately, in the current design, I was not able to identify a better possibility... We could get rid of the, if we refactor  the whole __setitem__ logic for tables (i.e. instead of having on_key_set,  we could override __setitem__ and fully control the changelog write + the store  write within tables/table.py::Table).

Any other ideas?



