### PR TITLE
Fixed table_routing failure on first bootup (Fixes #499)

### DIFF
--- a/faust/topics.py
+++ b/faust/topics.py
@@ -474,6 +474,7 @@ class Topic(SerializedChannel, TopicT):
                     deleting=self.deleting,
                     retention=self.retention,
                 )
+            await producer._producer.client.force_metadata_update()
 
     def __aiter__(self) -> ChannelT:
         if self.is_iterator:

--- a/t/unit/test_topics.py
+++ b/t/unit/test_topics.py
@@ -393,7 +393,7 @@ class test_Topic:
     @pytest.mark.asyncio
     async def test_declare(self, *, topic):
         topic.app.conf.topic_allow_declare = True
-        producer = Mock(create_topic=AsyncMock())
+        producer = Mock(create_topic=AsyncMock(), _producer=AsyncMock())
         topic._get_producer = AsyncMock(return_value=producer)
         topic.partitions = 101
         topic.replicas = 202
@@ -423,7 +423,7 @@ class test_Topic:
     @pytest.mark.asyncio
     async def test_declare__defaults(self, *, topic):
         topic.app.conf.topic_allow_declare = True
-        producer = Mock(create_topic=AsyncMock())
+        producer = Mock(create_topic=AsyncMock(), _producer=AsyncMock())
         topic._get_producer = AsyncMock(return_value=producer)
         topic.partitions = None
         topic.replicas = None


### PR DESCRIPTION
## Description

Fixes #499 

The issue seems to be that the metadata about the partitions available for a topic isn't up to date when the worker becomes read. This happens only when that topic was created by faust on that particular bootup. The changes in metadata gets reflected after 5 minutes (i believe this configuration isn't exposed to the user at this moment). A possible solution could be to reduce it from 5 minutes to 1 or 10 seconds or something. However, that would lead to the task running more frequently than it needs to.

Keeping this in mind, I've just forced the metadata to get updated as soon as the creation of all topics is completed.

I've been using this in a project for a few days. It seems to be working as expected. Not sure if this is the most efficient solution. Let me know if there is a different, better or more appropriate solution

Ran py.test. There were 2 failures due to the change I made, and I've fixed those test functions to account for the changes. All 1863 passed