### PR TITLE
Only wait for agents if the app started them

### DIFF
--- a/examples/advanced/rpc.py
+++ b/examples/advanced/rpc.py
@@ -32,5 +32,12 @@ async def _sender() -> None:
     async for value in pow.map([30.3, 40.4, 50.5, 60.6, 70.7, 80.8, 90.9]):
         print(f'RECEIVED REPLY: {value!r}')
 
+
+@app.command(faust.cli.argument('x'))
+async def x100(self, x):
+    res = await mul.ask(float(x))
+    print(f'{x} * 100 = {res}')
+
+
 if __name__ == '__main__':
     app.main()

--- a/faust/transport/conductor.py
+++ b/faust/transport/conductor.py
@@ -226,10 +226,13 @@ class Conductor(ConductorT, Service):
         # to give agents a chance to start up and register their
         # streams.  This way we won't have N subscription requests at the
         # start.
-        self.log.info('Waiting for agents to start...')
-        await self.app.agents.wait_until_agents_started()
-        self.log.info('Waiting for tables to be registered...')
-        await self.app.tables.wait_until_tables_registered()
+        if self.app.client_only or self.app.producer_only:
+            self.log.info('Not waiting for agent/table startups...')
+        else:
+            self.log.info('Waiting for agents to start...')
+            await self.app.agents.wait_until_agents_started()
+            self.log.info('Waiting for tables to be registered...')
+            await self.app.tables.wait_until_tables_registered()
         if not self.should_stop:
             # tell the consumer to subscribe to the topics.
             await self.app.consumer.subscribe(await self._update_indices())


### PR DESCRIPTION
## Description

Fixes #508 -- The conductor should only wait on the agent/tables startups to complete if the agent/tables were actually started up. In the case of `@app.command` and other methods, they won't be started, so waiting on them leads to a hang.