### PR TITLE
Remove `typing_extensions` import during runtime (its a dev dependency)

### DIFF
--- a/faust/models/typing.py
+++ b/faust/models/typing.py
@@ -27,6 +27,7 @@ from typing import (
     NamedTuple,
     Optional,
     Set,
+    TYPE_CHECKING,
     Tuple,
     Type,
     TypeVar,
@@ -43,12 +44,6 @@ from mode.utils.objects import (
     qualname,
 )
 from mode.utils.typing import Counter
-
-try:
-    from typing import Final
-except ImportError:
-    Final = object
-
 from faust.types.models import (
     CoercionHandler,
     CoercionMapping,
@@ -59,6 +54,14 @@ from faust.utils import codegen
 from faust.utils.functional import translate
 from faust.utils.iso8601 import parse as parse_iso8601
 from faust.utils.json import str_to_decimal
+
+if TYPE_CHECKING:
+    from typing_extensions import Final
+else:
+    try:
+        from typing import Final
+    except ImportError:
+        Final = object
 
 __all__ = ['NodeType', 'TypeExpression']
 

--- a/faust/models/typing.py
+++ b/faust/models/typing.py
@@ -55,9 +55,9 @@ from faust.utils.functional import translate
 from faust.utils.iso8601 import parse as parse_iso8601
 from faust.utils.json import str_to_decimal
 
-if TYPE_CHECKING:
+if TYPE_CHECKING: # pragma: no cover
     from typing_extensions import Final
-else:
+else: # pragma: no cover
     try:
         from typing import Final
     except ImportError:

--- a/faust/models/typing.py
+++ b/faust/models/typing.py
@@ -55,9 +55,9 @@ from faust.utils.functional import translate
 from faust.utils.iso8601 import parse as parse_iso8601
 from faust.utils.json import str_to_decimal
 
-if TYPE_CHECKING: # pragma: no cover
+if TYPE_CHECKING:  # pragma: no cover
     from typing_extensions import Final
-else: # pragma: no cover
+else:  # pragma: no cover
     try:
         from typing import Final
     except ImportError:

--- a/faust/models/typing.py
+++ b/faust/models/typing.py
@@ -43,7 +43,11 @@ from mode.utils.objects import (
     qualname,
 )
 from mode.utils.typing import Counter
-from typing_extensions import Final
+
+try:
+    from typing import Final
+except ImportError:
+    Final = object
 
 from faust.types.models import (
     CoercionHandler,


### PR DESCRIPTION
`typing_extensions` is not a runtime Faust dependency yet this runtime code uses it.
(its actually a dev dependency from mypy)

## Description

Recent release added an import line using `typing_extensions` which causes a `ModuleNotFound` exception as `typing_extension` is not a Faust dependency. 
As this library is not used anywhere else, I'm assuming this was a mistake...

```
  File "/opt/venv/lib/python3.8/site-packages/faust/__init__.py", line 252, in __getattr__
    module = __import__(
  File "/opt/venv/lib/python3.8/site-packages/faust/models/__init__.py", line 3, in <module>
    from .fields import FieldDescriptor, StringField
  File "/opt/venv/lib/python3.8/site-packages/faust/models/fields.py", line 32, in <module>
    from .typing import NodeType, TypeExpression
  File "/opt/venv/lib/python3.8/site-packages/faust/models/typing.py", line 46, in <module>
    from typing_extensions import Final
ModuleNotFoundError: No module named 'typing_extensions'
```
