### PR TITLE
Async operation on faust Schema

### DIFF
--- a/faust/channels.py
+++ b/faust/channels.py
@@ -649,6 +649,7 @@ class SerializedChannel(Channel[T]):
         if key is not None:
             schema = schema or self.schema
             assert schema is not None
+
             return await schema.dumps_key(
                 self.app, key,
                 serializer=key_serializer,

--- a/faust/channels.py
+++ b/faust/channels.py
@@ -229,7 +229,9 @@ class Channel(ChannelT[T]):
                   value_serializer: CodecArg = None,
                   callback: MessageSentCallback = None,
                   force: bool = False,
-                  eager_partitioning: bool = False) -> FutureMessage:
+                  eager_partitioning: bool = False,
+                  on_table_key_change: Callable = None,
+                  ) -> Awaitable[FutureMessage]:
         """Produce message by adding to buffer.
 
         This method is only supported by :class:`~faust.Topic`.

--- a/faust/events.py
+++ b/faust/events.py
@@ -219,19 +219,19 @@ class Event(EventT):
             force=force,
         )
 
-    def _attach(self,
-                channel: Union[ChannelT, str],
-                key: K = None,
-                value: V = None,
-                partition: int = None,
-                timestamp: float = None,
-                headers: HeadersArg = None,
-                schema: SchemaT = None,
-                key_serializer: CodecArg = None,
-                value_serializer: CodecArg = None,
-                callback: MessageSentCallback = None,
-                ) -> Awaitable[RecordMetadata]:
-        return cast(_App, self.app)._attachments.put(
+    async def _attach(self,
+                      channel: Union[ChannelT, str],
+                      key: K = None,
+                      value: V = None,
+                      partition: int = None,
+                      timestamp: float = None,
+                      headers: HeadersArg = None,
+                      schema: SchemaT = None,
+                      key_serializer: CodecArg = None,
+                      value_serializer: CodecArg = None,
+                      callback: MessageSentCallback = None,
+                      ) -> Awaitable[RecordMetadata]:
+        return await cast(_App, self.app)._attachments.put(
             self.message,
             channel,
             key,

--- a/faust/serializers/registry.py
+++ b/faust/serializers/registry.py
@@ -97,12 +97,33 @@ class Registry(RegistryT):
         serializer = self._serializer(typ, serializer, self.value_serializer)
         try:
             payload = self._loads(serializer, value)
-            return cast(V, self._prepare_payload(typ, payload))
+            return self.loads_from_payload(typ, payload)
         except MemoryError:
             raise
         except Exception as exc:
             raise ValueDecodeError(str(exc)).with_traceback(
                 sys.exc_info()[2]) from exc
+
+    def loads_from_payload(self, typ: Optional[ModelArg], payload: Any):
+        """
+        Return a specific instance according to the payload and type received.
+
+        Arguments:
+            typ (optional): Model to use for deserialization.
+            payload (Any): python object.
+
+        Example:
+
+            class Point(Record, serializer='json'):
+                x: int
+                y: int
+
+            typ = Point
+            payload = {"x": 10, "y": 100}
+
+            point_instance = self.loads_from_payload(paylaod)
+        """
+        return cast(V, self._prepare_payload(typ, payload))
 
     def _prepare_payload(self, typ: Optional[ModelArg], value: Any) -> Any:
         if typ is None:  # (autodetect)

--- a/faust/serializers/registry.py
+++ b/faust/serializers/registry.py
@@ -104,7 +104,7 @@ class Registry(RegistryT):
             raise ValueDecodeError(str(exc)).with_traceback(
                 sys.exc_info()[2]) from exc
 
-    def loads_from_payload(self, typ: Optional[ModelArg], payload: Any):
+    def loads_from_payload(self, typ: Optional[ModelArg], payload: Any) -> Any:
         """
         Return a specific instance according to the payload and type received.
 

--- a/faust/serializers/schemas.py
+++ b/faust/serializers/schemas.py
@@ -65,9 +65,9 @@ class Schema(SchemaT):
         if allow_empty is not None:
             self.allow_empty = allow_empty
 
-    def loads_key(self, app: AppT, message: Message, *,
-                  loads: Callable = None,
-                  serializer: CodecArg = None) -> KT:
+    async def loads_key(self, app: AppT, message: Message, *,
+                        loads: Callable = None,
+                        serializer: CodecArg = None) -> KT:
         if loads is None:
             loads = app.serializers.loads_key
         return cast(KT, loads(
@@ -75,9 +75,9 @@ class Schema(SchemaT):
             serializer=serializer or self.key_serializer,
         ))
 
-    def loads_value(self, app: AppT, message: Message, *,
-                    loads: Callable = None,
-                    serializer: CodecArg = None) -> VT:
+    async def loads_value(self, app: AppT, message: Message, *,
+                          loads: Callable = None,
+                          serializer: CodecArg = None) -> VT:
         if loads is None:
             loads = app.serializers.loads_value
         return loads(
@@ -85,18 +85,22 @@ class Schema(SchemaT):
             serializer=serializer or self.value_serializer,
         )
 
-    def dumps_key(self, app: AppT, key: K, *,
-                  serializer: CodecArg = None,
-                  headers: OpenHeadersArg) -> Tuple[Any, OpenHeadersArg]:
+    async def dumps_key(
+        self, app: AppT, key: K, *,
+        serializer: CodecArg = None,
+        headers: OpenHeadersArg,
+    ) -> Tuple[Any, OpenHeadersArg]:
         payload = app.serializers.dumps_key(
             self.key_type, key,
             serializer=serializer or self.key_serializer,
         )
         return payload, self.on_dumps_key_prepare_headers(key, headers)
 
-    def dumps_value(self, app: AppT, value: V, *,
-                    serializer: CodecArg = None,
-                    headers: OpenHeadersArg) -> Tuple[Any, OpenHeadersArg]:
+    async def dumps_value(
+        self, app: AppT, value: V, *,
+        serializer: CodecArg = None,
+        headers: OpenHeadersArg,
+    ) -> Tuple[Any, OpenHeadersArg]:
         payload = app.serializers.dumps_value(
             self.value_type, value,
             serializer=serializer or self.value_serializer,
@@ -134,7 +138,7 @@ class Schema(SchemaT):
         async def decode(message: Message, *,
                          propagate: bool = default_propagate) -> Any:
             try:
-                k: K = schema_loads_key(app, message, loads=loads_key)
+                k: K = await schema_loads_key(app, message, loads=loads_key)
             except KeyDecodeError as exc:
                 if propagate:
                     raise
@@ -143,7 +147,8 @@ class Schema(SchemaT):
                 try:
                     if message.value is None and allow_empty:
                         return create_event(k, None, message.headers, message)
-                    v: V = schema_loads_value(app, message, loads=loads_value)
+                    v: V = await schema_loads_value(
+                        app, message, loads=loads_value)
                 except ValueDecodeError as exc:
                     if propagate:
                         raise

--- a/faust/tables/base.py
+++ b/faust/tables/base.py
@@ -254,7 +254,8 @@ class Collection(Service, CollectionT):
                        key: Any,
                        value: Any,
                        key_serializer: CodecArg = None,
-                       value_serializer: CodecArg = None) -> FutureMessage:
+                       value_serializer: CodecArg = None,
+                       on_table_key_change: Callable = None) -> FutureMessage:
         """Send modification event to changelog topic."""
         if key_serializer is None:
             key_serializer = self.key_serializer
@@ -269,7 +270,7 @@ class Collection(Service, CollectionT):
             callback=self._on_changelog_sent,
             # Ensures final partition number is ready in ret.message.partition
             eager_partitioning=True,
-        )
+            on_table_key_change=on_table_key_change)
 
     def _send_changelog(self,
                         event: Optional[EventT],

--- a/faust/tables/base.py
+++ b/faust/tables/base.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from heapq import heappop, heappush
 from typing import (
     Any,
+    Awaitable,
     Callable,
     Iterable,
     Iterator,
@@ -255,7 +256,8 @@ class Collection(Service, CollectionT):
                        value: Any,
                        key_serializer: CodecArg = None,
                        value_serializer: CodecArg = None,
-                       on_table_key_change: Callable = None) -> FutureMessage:
+                       on_table_key_change: Callable = None,
+                       ) -> Awaitable[FutureMessage]:
         """Send modification event to changelog topic."""
         if key_serializer is None:
             key_serializer = self.key_serializer

--- a/faust/topics.py
+++ b/faust/topics.py
@@ -205,14 +205,15 @@ class Topic(SerializedChannel, TopicT):
                   value_serializer: CodecArg = None,
                   callback: MessageSentCallback = None,
                   force: bool = False,
-                  eager_partitioning: bool = False) -> FutureMessage:
+                  eager_partitioning: bool = False,
+                  on_table_key_change: Callable = None) -> Awaitable:
         """Produce message by adding to buffer.
 
         Notes:
             This method can be used by non-`async def` functions
             to produce messages.
         """
-        fut = self.as_future_message(
+        fut_awaitable = self.as_future_message(
             key=key,
             value=value,
             partition=partition,
@@ -223,9 +224,10 @@ class Topic(SerializedChannel, TopicT):
             value_serializer=value_serializer,
             callback=callback,
             eager_partitioning=eager_partitioning,
+            on_table_key_change=on_table_key_change,
         )
-        self.app.producer.send_soon(fut)
-        return fut
+        self.app.producer.send_soon(fut_awaitable)
+        return fut_awaitable
 
     async def put(self, event: EventT) -> None:
         """Put event directly onto the underlying queue of this topic.

--- a/faust/topics.py
+++ b/faust/topics.py
@@ -169,7 +169,7 @@ class Topic(SerializedChannel, TopicT):
         if app._attachments.enabled and not force:
             event = current_event()
             if event is not None:
-                return cast(Event, event)._attach(
+                return await cast(Event, event)._attach(
                     self,
                     key,
                     value,
@@ -206,7 +206,8 @@ class Topic(SerializedChannel, TopicT):
                   callback: MessageSentCallback = None,
                   force: bool = False,
                   eager_partitioning: bool = False,
-                  on_table_key_change: Callable = None) -> Awaitable:
+                  on_table_key_change: Callable = None,
+                  ) -> Awaitable[FutureMessage]:
         """Produce message by adding to buffer.
 
         Notes:

--- a/faust/transport/consumer.py
+++ b/faust/transport/consumer.py
@@ -284,7 +284,7 @@ class TransactionManager(Service, TransactionManagerT):
             transactional_id=transactional_id,
         )
 
-    def send_soon(self, fut: FutureMessage) -> None:
+    def send_soon(self, fut: Awaitable[FutureMessage]) -> None:
         raise NotImplementedError()
 
     async def send_and_wait(self, topic: str, key: Optional[bytes],

--- a/faust/transport/producer.py
+++ b/faust/transport/producer.py
@@ -90,7 +90,8 @@ class ProducerBuffer(Service, ProducerBufferT):
         get_pending = self.pending.get
         send_pending = self._send_pending
         while not self.should_stop:
-            msg = await get_pending()
+            coro = await get_pending()
+            msg = await coro
             await send_pending(msg)
 
     @property

--- a/faust/transport/producer.py
+++ b/faust/transport/producer.py
@@ -24,7 +24,7 @@ class ProducerBuffer(Service, ProducerBufferT):
     def __post_init__(self) -> None:
         self.pending = asyncio.Queue()
 
-    def put(self, fut: FutureMessage) -> None:
+    def put(self, fut: Awaitable[FutureMessage]) -> None:
         """Add message to buffer.
 
         The message will be eventually produced, you can await
@@ -144,7 +144,7 @@ class Producer(Service, ProducerT):
         """Schedule message to be sent by producer."""
         raise NotImplementedError()
 
-    def send_soon(self, fut: FutureMessage) -> None:
+    def send_soon(self, fut: Awaitable[FutureMessage]) -> None:
         self.buffer.put(fut)
 
     async def send_and_wait(self, topic: str, key: Optional[bytes],

--- a/faust/types/channels.py
+++ b/faust/types/channels.py
@@ -5,6 +5,7 @@ from typing import (
     Any,
     AsyncIterator,
     Awaitable,
+    Callable,
     Generic,
     Optional,
     Set,
@@ -111,7 +112,9 @@ class ChannelT(AsyncIterator[_EventT[_T]]):
                   value_serializer: CodecArg = None,
                   callback: MessageSentCallback = None,
                   force: bool = False,
-                  eager_partitioning: bool = False) -> FutureMessage:
+                  eager_partitioning: bool = False,
+                  on_table_key_change: Callable = None,
+                  ) -> Awaitable[FutureMessage]:
         ...
 
     @abc.abstractmethod
@@ -126,7 +129,8 @@ class ChannelT(AsyncIterator[_EventT[_T]]):
             key_serializer: CodecArg = None,
             value_serializer: CodecArg = None,
             callback: MessageSentCallback = None,
-            eager_partitioning: bool = False) -> FutureMessage:
+            eager_partitioning: bool = False,
+            on_table_key_change: Callable = None) -> Awaitable[FutureMessage]:
         ...
 
     @abc.abstractmethod

--- a/faust/types/serializers.py
+++ b/faust/types/serializers.py
@@ -1,6 +1,6 @@
 import abc
 import typing
-from typing import Any, Callable, Generic, Optional, Tuple, TypeVar
+from typing import Any, Awaitable, Callable, Generic, Optional, Tuple, TypeVar
 
 from .codecs import CodecArg
 from .core import K, OpenHeadersArg, V
@@ -94,25 +94,27 @@ class SchemaT(Generic[KT, VT]):
     @abc.abstractmethod
     def loads_key(self, app: _AppT, message: _Message, *,
                   loads: Callable = None,
-                  serializer: CodecArg = None) -> KT:
+                  serializer: CodecArg = None) -> Awaitable[KT]:
         ...
 
     @abc.abstractmethod
     def loads_value(self, app: _AppT, message: _Message, *,
                     loads: Callable = None,
-                    serializer: CodecArg = None) -> VT:
+                    serializer: CodecArg = None) -> Awaitable[VT]:
         ...
 
     @abc.abstractmethod
     def dumps_key(self, app: _AppT, key: K, *,
                   serializer: CodecArg = None,
-                  headers: OpenHeadersArg) -> Tuple[Any, OpenHeadersArg]:
+                  headers: OpenHeadersArg,
+                  ) -> Awaitable[Tuple[Any, OpenHeadersArg]]:
         ...
 
     @abc.abstractmethod
     def dumps_value(self, app: _AppT, value: V, *,
                     serializer: CodecArg = None,
-                    headers: OpenHeadersArg) -> Tuple[Any, OpenHeadersArg]:
+                    headers: OpenHeadersArg,
+                    ) -> Awaitable[Tuple[Any, OpenHeadersArg]]:
         ...
 
     @abc.abstractmethod

--- a/faust/types/tables.py
+++ b/faust/types/tables.py
@@ -156,7 +156,8 @@ class CollectionT(ServiceT, JoinableT):
                        key: Any,
                        value: Any,
                        key_serializer: CodecArg = None,
-                       value_serializer: CodecArg = None) -> FutureMessage:
+                       value_serializer: CodecArg = None,
+                       ) -> Awaitable[FutureMessage]:
         ...
 
     @abc.abstractmethod

--- a/faust/types/transports.py
+++ b/faust/types/transports.py
@@ -79,7 +79,7 @@ class ProducerBufferT(ServiceT):
     pending: asyncio.Queue
 
     @abc.abstractmethod
-    def put(self, fut: FutureMessage) -> None:
+    def put(self, fut: Awaitable[FutureMessage]) -> None:
         ...
 
     @abc.abstractmethod
@@ -134,7 +134,7 @@ class ProducerT(ServiceT):
         ...
 
     @abc.abstractmethod
-    def send_soon(self, fut: FutureMessage) -> None:
+    def send_soon(self, fut: Awaitable[FutureMessage]) -> None:
         ...
 
     @abc.abstractmethod

--- a/t/conftest.py
+++ b/t/conftest.py
@@ -16,6 +16,8 @@ from mode.utils.mocks import (
     patch,
 )
 
+from faust.types import FutureMessage, PendingMessage
+
 sentinel = object()
 
 
@@ -293,3 +295,25 @@ def pytest_configure(config):
         'markers',
         'http_session: Set mock aiohttp session result',
     )
+
+
+@pytest.fixture()
+def future_message():
+    def future(topic):
+        callback = Mock(name='callback')
+        headers = {'k': 'v'}
+        return FutureMessage(
+            PendingMessage(
+                topic,
+                key='foo',
+                value='bar',
+                partition=130,
+                timestamp=312.5134,
+                headers=headers,
+                key_serializer='json',
+                value_serializer='json',
+                callback=callback,
+            ),
+        )
+
+    return future

--- a/t/functional/serializers/test_registry.py
+++ b/t/functional/serializers/test_registry.py
@@ -156,6 +156,17 @@ def test_loads_value(payload, typ, serializer, expected, *, app):
         typ, payload, serializer=serializer) == expected
 
 
+def test_loads_from_payload(app):
+    payload = {
+        'id': 'A2',
+        'first_name': 'George',
+        'last_name': 'Costanza',
+    }
+    user = app.serializers.loads_from_payload(User, payload)
+
+    assert isinstance(user, User)
+
+
 def test_loads_value_missing_key_raises_error(*, app):
     account = ACCOUNT1.to_representation()
     account.pop('active')

--- a/t/functional/test_channels.py
+++ b/t/functional/test_channels.py
@@ -236,10 +236,11 @@ async def test_deliver(*, channel, app):
     assert event.message is msg
 
 
-def test_as_future_message__eager_partitioning(*, app):
+@pytest.mark.asyncio
+async def test_as_future_message__eager_partitioning(*, app):
     topic = app.topic('foo')
     app.producer = Mock(name='producer')
-    fut = topic.as_future_message(
+    fut = await topic.as_future_message(
         key=b'foo',
         value=b'bar',
         partition=None,
@@ -248,10 +249,13 @@ def test_as_future_message__eager_partitioning(*, app):
     assert fut.message.partition is not None
 
 
-def test_as_future_message__eager_partitioning_on_channel(*, channel, app):
+@pytest.mark.asyncio
+async def test_as_future_message__eager_partitioning_on_channel(
+    *, channel, app,
+):
     app.producer = Mock(name='producer')
     with pytest.raises(NotImplementedError):
-        channel.as_future_message(
+        await channel.as_future_message(
             key=b'foo',
             value=b'bar',
             partition=None,

--- a/t/unit/tables/test_base.py
+++ b/t/unit/tables/test_base.py
@@ -139,6 +139,7 @@ class test_Collection:
             value_serializer='json',
             callback=table._on_changelog_sent,
             eager_partitioning=True,
+            on_table_key_change=None,
         )
 
     def test_send_changelog__custom_serializers(self, *, table):
@@ -157,6 +158,7 @@ class test_Collection:
             value_serializer='raw',
             callback=table._on_changelog_sent,
             eager_partitioning=True,
+            on_table_key_change=None,
         )
 
     def test_send_changelog__no_current_event(self, *, table):

--- a/t/unit/test_events.py
+++ b/t/unit/test_events.py
@@ -139,11 +139,12 @@ class test_Event:
             force=False,
         )
 
-    def test_attach(self, *, event, app):
+    @pytest.mark.asyncio
+    async def test_attach(self, *, event, app):
         callback = Mock(name='callback')
         schema = Mock(name='schema')
-        app._attachments.put = Mock(name='_attachments.put')
-        result = event._attach(
+        app._attachments.put = AsyncMock(name='_attachments.put')
+        result = await event._attach(
             channel='chan',
             key=b'k',
             value=b'v',
@@ -168,7 +169,7 @@ class test_Event:
             value_serializer='vser',
             callback=callback,
         )
-        assert result is app._attachments.put()
+        assert result is await app._attachments.put()
 
     @pytest.mark.asyncio
     async def test__send(self, *, event, app):

--- a/t/unit/test_topics.py
+++ b/t/unit/test_topics.py
@@ -164,7 +164,11 @@ class test_Topic:
         app._attachments.enabled = True
         callback = Mock(name='callback')
         schema = Mock(name='schema')
-        with patch('faust.topics.current_event') as current_event:
+
+        event = Mock('current_event', _attach=AsyncMock())
+
+        with patch('faust.topics.current_event',
+                   return_value=event) as current_event:
             await topic.send(
                 key='k',
                 value='v',

--- a/t/unit/transport/test_producer.py
+++ b/t/unit/transport/test_producer.py
@@ -1,5 +1,5 @@
 import pytest
-from mode.utils.mocks import AsyncMock, Mock, call
+from mode.utils.mocks import AsyncMock, Mock
 from faust.transport.producer import Producer, ProducerBuffer
 
 
@@ -32,22 +32,30 @@ class test_ProducerBuffer:
         )
 
     @pytest.mark.asyncio
-    async def test__handle_pending(self, *, buf):
-        buf.pending = Mock(get=AsyncMock())
-        buf._send_pending = AsyncMock()
+    async def test__handle_pending(self, *, buf, app, future_message):
+        message = future_message(app.topic('foo'))
+
+        async def get_pending():
+            async def async_func():
+                return message
+            return async_func()
 
         async def on_send(fut):
             if buf._send_pending.call_count >= 3:
                 buf._stopped.set()
 
+        buf.pending = Mock(get=get_pending)
+        buf._send_pending = AsyncMock()
+
         buf._send_pending.side_effect = on_send
 
         await buf._handle_pending(buf)
+        buf._send_pending.assert_called_with(message)
 
-        buf._send_pending.assert_has_calls([
-            call(buf.pending.get.coro.return_value),
-            call(buf.pending.get.coro.return_value),
-        ])
+        # buf._send_pending.assert_has_calls([
+        #     call(buf.pending.get.coro.return_value),
+        #     call(buf.pending.get.coro.return_value),
+        # ])
 
     @pytest.mark.asyncio
     async def test_wait_until_ebb(self, *, buf):

--- a/t/unit/transport/test_producer.py
+++ b/t/unit/transport/test_producer.py
@@ -52,11 +52,6 @@ class test_ProducerBuffer:
         await buf._handle_pending(buf)
         buf._send_pending.assert_called_with(message)
 
-        # buf._send_pending.assert_has_calls([
-        #     call(buf.pending.get.coro.return_value),
-        #     call(buf.pending.get.coro.return_value),
-        # ])
-
     @pytest.mark.asyncio
     async def test_wait_until_ebb(self, *, buf):
         buf.max_messages = 10


### PR DESCRIPTION
## Description

Convert `Schema` sync methods to async methods (loads_key, loads_value, dumps_key and dumps_value). With this new functionality we will able to perform `async` operation in our custom schemas.

## Use Case

A use case could be working with `avro schemas`. In order to `serialize/deserialize` events we need an avro schema that usually we get from a schema server (request/response). 

With the current state (sync methods), we could get schemas but the operation will block the event loop (waiting to complete the requests and not releasing the event loop). With the new functionality (async), we can perform `i/o` tasks like `get avro schemas`.

## Example:

```python
import faust

class User(faust.Record):
    user_id: str
    content: str

class MySchema(faust.Schema):

    async def loads_value(
        self, app, message, *,
        loads=None,
        serializer=None
    ):
        loads = app.serializers.loads_from_payload
        schema = avro_schema_server.get("user_schema") 

        # {"user_id": "100", "content": "Hi..."}
        payload = schema.decode(message)

        return loads(self.value_type, payload)

    async def dumps_value(self, app, value, *, serializer=None, headers=None):
        # some example of awaiting another task
        await asyncio.sleep(1)
        
        return await super().dumps_value(
            app, value, serializer=serializer, headers=headers)


schema = MySchema(value_type=User)
user_topic = app.topic("test-user-topic", schema=schema)

@app.agent(user_topic)
async def my_agent(messages):
    async for message in messages:
        ...
```

This new feature could be an intermediate step to have `async` methods over `codecs` as well.

PD: This feature introduce a breaking change for all the users that have defined custom schemas (the way to fix it will we adding `async to the methods`), for the rest should work like usual. 
