### PR TITLE
feat(window): Async coroutine supported in windows callback

### DIFF
--- a/faust/tables/base.py
+++ b/faust/tables/base.py
@@ -24,8 +24,7 @@ from typing import (
     no_type_check,
 )
 
-from inspect import iscoroutinefunction
-
+from mode.utils.futures import maybe_async
 from mode import Seconds, Service
 from yarl import URL
 
@@ -377,10 +376,7 @@ class Collection(Service, CollectionT):
 
     async def on_window_close(self, key: Any, value: Any) -> None:
         if self._on_window_close:
-            if(iscoroutinefunction(self._on_window_close)):
-                await self._on_window_close(key, value)
-            else:
-                self._on_window_close(key, value)
+            await maybe_async(self._on_window_close(key, value))
 
     def _should_expire_keys(self) -> bool:
         window = self.window

--- a/faust/tables/base.py
+++ b/faust/tables/base.py
@@ -9,9 +9,7 @@ from datetime import datetime
 from heapq import heappop, heappush
 from typing import (
     Any,
-    Awaitable,
     Callable,
-    Coroutine,
     Iterable,
     Iterator,
     List,
@@ -357,7 +355,7 @@ class Collection(Service, CollectionT):
                     interval, name='table_cleanup'):
                 await self._del_old_keys()
 
-    async def _del_old_keys(self) -> Coroutine[Any, Any, None]:
+    async def _del_old_keys(self) -> None:
         window = cast(WindowT, self.window)
         assert window
         for partition, timestamps in self._partition_timestamps.items():
@@ -377,7 +375,7 @@ class Collection(Service, CollectionT):
                         max(key[1][0] for key in keys_to_remove),
                     )
 
-    async def on_window_close(self, key: Any, value: Any) -> Awaitable[Any]:
+    async def on_window_close(self, key: Any, value: Any) -> None:
         if self._on_window_close:
             if(iscoroutinefunction(self._on_window_close)):
                 await self._on_window_close(key, value)

--- a/faust/tables/base.py
+++ b/faust/tables/base.py
@@ -9,7 +9,9 @@ from datetime import datetime
 from heapq import heappop, heappush
 from typing import (
     Any,
+    Awaitable,
     Callable,
+    Coroutine,
     Iterable,
     Iterator,
     List,
@@ -355,7 +357,7 @@ class Collection(Service, CollectionT):
                     interval, name='table_cleanup'):
                 await self._del_old_keys()
 
-    async def _del_old_keys(self) -> None:
+    async def _del_old_keys(self) -> Coroutine[Any, Any, None]:
         window = cast(WindowT, self.window)
         assert window
         for partition, timestamps in self._partition_timestamps.items():
@@ -375,7 +377,7 @@ class Collection(Service, CollectionT):
                         max(key[1][0] for key in keys_to_remove),
                     )
 
-    async def on_window_close(self, key: Any, value: Any) -> None:
+    async def on_window_close(self, key: Any, value: Any) -> Awaitable[Any]:
         if self._on_window_close:
             if(iscoroutinefunction(self._on_window_close)):
                 await self._on_window_close(key, value)

--- a/faust/types/tables.py
+++ b/faust/types/tables.py
@@ -5,6 +5,7 @@ from typing import (
     Any,
     Awaitable,
     Callable,
+    Coroutine,
     ItemsView,
     Iterable,
     Iterator,
@@ -61,7 +62,7 @@ __all__ = [
 RelativeHandler = Callable[[Optional[EventT]], Union[float, datetime]]
 RecoverCallback = Callable[[], Awaitable[None]]
 ChangelogEventCallback = Callable[[EventT], Awaitable[None]]
-WindowCloseCallback = Callable[[Any, Any], None]
+WindowCloseCallback = Callable[[Any, Any], Awaitable[None]]
 RelativeArg = Optional[Union[
     _FieldDescriptorT,
     RelativeHandler,
@@ -164,7 +165,8 @@ class CollectionT(ServiceT, JoinableT):
         ...
 
     @abc.abstractmethod
-    def on_window_close(self, key: Any, value: Any) -> None:
+    def on_window_close(self, key: Any,
+                        value: Any) -> Coroutine[Any, Any, None]:
         ...
 
     @abc.abstractmethod

--- a/faust/types/tables.py
+++ b/faust/types/tables.py
@@ -5,7 +5,6 @@ from typing import (
     Any,
     Awaitable,
     Callable,
-    Coroutine,
     ItemsView,
     Iterable,
     Iterator,
@@ -62,7 +61,7 @@ __all__ = [
 RelativeHandler = Callable[[Optional[EventT]], Union[float, datetime]]
 RecoverCallback = Callable[[], Awaitable[None]]
 ChangelogEventCallback = Callable[[EventT], Awaitable[None]]
-WindowCloseCallback = Callable[[Any, Any], Awaitable[None]]
+WindowCloseCallback = Callable[[Any, Any], Union[None, Awaitable[None]]]
 RelativeArg = Optional[Union[
     _FieldDescriptorT,
     RelativeHandler,
@@ -165,8 +164,7 @@ class CollectionT(ServiceT, JoinableT):
         ...
 
     @abc.abstractmethod
-    def on_window_close(self, key: Any,
-                        value: Any) -> Coroutine[Any, Any, None]:
+    async def on_window_close(self, key: Any, value: Any) -> None:
         ...
 
     @abc.abstractmethod


### PR DESCRIPTION

## Description

This PR closes #519 , Faust naturally supports async/await but that flow breaks in the `on_window_close` callable. 

Fix: on_window_close now can be `python callable` or `python coroutine` i.e async function

As mentioned in the [examples/windowed_aggregation.py](https://github.com/robinhood/faust/pull/446/files)

```python3
def window_processor(key, events):
    timestamp = key[1][0]
    values = [event.value for event in events]
    count = len(values)
    mean = sum(values) / count

    print(
        f'processing window:'
        f'{len(values)} events,'
        f'mean: {mean:.2f},'
        f'timestamp {timestamp}',
    )

    sink.send_soon(value=AggModel(date=timestamp, count=count, mean=mean))

``` 

The same function can now be `async function` e.g

```python3
async def window_processor(key, events):
    timestamp = key[1][0]
    values = [event.value for event in events]
    count = len(values)
    mean = sum(values) / count

    print(
        f'processing window:'
        f'{len(values)} events,'
        f'mean: {mean:.2f},'
        f'timestamp {timestamp}',
    )

    sink.send_soon(value=AggModel(date=timestamp, count=count, mean=mean))

``` 

> Note: This PR is built and tested on

```
Python 3.6.9 (default, Nov  7 2019, 10:44:02) 
[GCC 8.3.0] on linux

```

PS: First PR :) 

