### PR TITLE
make simple coercion work

### DIFF
--- a/faust/models/fields.py
+++ b/faust/models/fields.py
@@ -171,10 +171,9 @@ class FieldDescriptor(FieldDescriptorT[T]):
         self._to_python = self._compile_type_expression()
 
     def _prepare_type_expression(self) -> TypeExpression:
-        assert self.model is not None
         expr = TypeExpression(
             self.type,
-            user_types=self.model._options.coercions,
+            user_types=self.options['model_coercions'],
             date_parser=self.date_parser,
         )
         return expr

--- a/faust/models/record.py
+++ b/faust/models/record.py
@@ -264,6 +264,7 @@ class Record(Model, abstract=True):  # type: ignore
                     default=default,
                     parent=parent,
                     coerce=coerce,
+                    model_coercions=options.coercions,
                     date_parser=date_parser,
                     tag=tag,
                 )
@@ -276,6 +277,7 @@ class Record(Model, abstract=True):  # type: ignore
                     default=default,
                     parent=parent,
                     coerce=coerce,
+                    model_coercions=options.coercions,
                 )
 
             descr.on_model_attached()


### PR DESCRIPTION
coercion works for nested and inherited models but not for the simplest case where coercion dict is defined on the record

this is because compilation of the fields happen before options are set on the record.

This commit fix the issue by passing explicitly the coercion of the model to the fields.