### PR TITLE
Remove docs links to deprecated mailing list

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -119,7 +119,7 @@ If you'd like to submit the information encrypted our PGP key is::
 Other bugs
 ----------
 
-Bugs can always be described to the `mailing-list`_, but the best
+Bugs can always be described to the `slack-channel`_, but the best
 way to report an issue and to ensure a timely response is to use the
 issue tracker.
 
@@ -133,7 +133,7 @@ and participate in the discussion.
 2) **Determine if your bug is really a bug**.
 
 You shouldn't file a bug if you're requesting support. For that you can use
-the `mailing-list`_, or `slack-channel`_.
+the `slack-channel`_.
 
 3) **Make sure your bug hasn't already been reported**.
 
@@ -204,7 +204,7 @@ issue tracker.
 * ``Mode`` - https://github.com/ask/mode/issues
 
 If you're unsure of the origin of the bug you can ask the
-`mailing-list`_, or just use the Faust issue tracker.
+`slack-channel`_, or just use the Faust issue tracker.
 
 Contributors guide to the code base
 ===================================
@@ -908,8 +908,6 @@ following:
     the ``1.0`` branch for the 1.0 series.
 
 * Also add the previous version under the "versions" tab.
-
-.. _`mailing-list`: https://groups.google.com/group/faust-users
 
 .. _`slack-channel`: http://faust.readthedocs.io/en/latest/getting-started/resources.html#slack-channel
 

--- a/README.rst
+++ b/README.rst
@@ -482,24 +482,16 @@ Faust supports kafka with version >= 0.10.
 Getting Help
 ============
 
-.. _mailing-list:
-
-Mailing list
-------------
-
-For discussions about the usage, development, and future of Faust,
-please join the `faust-users`_ mailing list.
-
-.. _`faust-users`: https://groups.google.com/group/faust-users/
-
 .. _slack-channel:
 
 Slack
 -----
 
-Come chat with us on Slack:
+For discussions about the usage, development, and future of Faust,
+please join the `fauststream`_ Slack.
 
-https://join.slack.com/t/fauststream/shared_invite/enQtNDEzMTIyMTUyNzU2LTIyMjNjY2M2YzA2OWFhMDlmMzVkODk3YTBlYThlYmZiNTUwZDJlYWZiZTdkN2Q4ZGU4NWM4YWMyNTM5MGQ5OTg
+* https://fauststream.slack.com
+* Sign-up: https://join.slack.com/t/fauststream/shared_invite/enQtNDEzMTIyMTUyNzU2LTIyMjNjY2M2YzA2OWFhMDlmMzVkODk3YTBlYThlYmZiNTUwZDJlYWZiZTdkN2Q4ZGU4NWM4YWMyNTM5MGQ5OTg
 
 Resources
 =========

--- a/docs/includes/resources.txt
+++ b/docs/includes/resources.txt
@@ -3,24 +3,16 @@
 Getting Help
 ============
 
-.. _mailing-list:
-
-Mailing list
-------------
-
-For discussions about the usage, development, and future of Faust,
-please join the `faust-users`_ mailing list.
-
-.. _`faust-users`: https://groups.google.com/group/faust-users/
-
 .. _slack-channel:
 
 Slack
 -----
 
-Come chat with us on Slack:
+For discussions about the usage, development, and future of Faust,
+please join the `fauststream`_ Slack.
 
-https://join.slack.com/t/fauststream/shared_invite/enQtNDEzMTIyMTUyNzU2LTIyMjNjY2M2YzA2OWFhMDlmMzVkODk3YTBlYThlYmZiNTUwZDJlYWZiZTdkN2Q4ZGU4NWM4YWMyNTM5MGQ5OTg
+* https://fauststream.slack.com
+* Sign-up: https://join.slack.com/t/fauststream/shared_invite/enQtNDEzMTIyMTUyNzU2LTIyMjNjY2M2YzA2OWFhMDlmMzVkODk3YTBlYThlYmZiNTUwZDJlYWZiZTdkN2Q4ZGU4NWM4YWMyNTM5MGQ5OTg
 
 Resources
 =========

--- a/extra/release/sphinx2rst_config.py
+++ b/extra/release/sphinx2rst_config.py
@@ -1,8 +1,5 @@
 REFBASE = 'http://faust.readthedocs.io/en/latest'
 REFS = {
-    'mailing-list':
-        'https://groups.google.com/group/faust-users',
-    'irc-channel': 'getting-started/resources.html#irc-channel',
     'slack-channel': 'getting-started/resources.html#slack-channel',
     'bundles': 'introduction/installation.html#bundles',
     'reporting-bugs': 'contributing.html#reporting-bugs',


### PR DESCRIPTION
Based on https://github.com/robinhood/faust/issues/438#issuecomment-540820915 it seems the mailing list is deprecated. This PR removes it's mention, to avoid confusion / frustration by new users.