### PR TITLE
Update docs wording on Python 2 and 3.5 support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -416,47 +416,11 @@ Can I use Faust with Twisted?
 Yes! Use the ``asyncio`` reactor implementation:
 https://twistedmatrix.com/documents/17.1.0/api/twisted.internet.asyncioreactor.html
 
-Will you support Python 3.5 or earlier?
----------------------------------------
+Will you support Python 2.7 or Python 3.5?
+------------------------------------------
 
-There are no immediate plans to support Python 3.5, but you are welcome to
-contribute to the project.
-
-Here are some of the steps required to accomplish this:
-
-- Source code transformation to rewrite variable annotations to comments
-
-  for example, the code::
-
-        class Point:
-            x: int = 0
-            y: int = 0
-
-   must be rewritten into::
-
-        class Point:
-            x = 0  # type: int
-            y = 0  # type: int
-
-- Source code transformation to rewrite async functions
-
-    for example, the code::
-
-        async def foo():
-            await asyncio.sleep(1.0)
-
-    must be rewritten into::
-
-        @coroutine
-        def foo():
-            yield from asyncio.sleep(1.0)
-
-Will you support Python 2?
---------------------------
-
-There are no plans to support Python 2, but you are welcome to contribute to
-the project (details in the question above is relevant also for Python 2).
-
+No. Faust requires Python 3.6 or later, since it heavily uses features that were
+introduced in Python 3.6 (`async`, `await`, variable type annotations).
 
 I get a maximum number of open files exceeded error by RocksDB when running a Faust app locally. How can I fix this?
 --------------------------------------------------------------------------------------------------------------------

--- a/docs/includes/faq.txt
+++ b/docs/includes/faq.txt
@@ -51,46 +51,12 @@ Can I use Faust with Twisted?
 Yes! Use the :mod:`asyncio` reactor implementation:
 https://twistedmatrix.com/documents/17.1.0/api/twisted.internet.asyncioreactor.html
 
-Will you support Python 3.5 or earlier?
----------------------------------------
 
-There are no immediate plans to support Python 3.5, but you are welcome to
-contribute to the project.
+Will you support Python 2.7 or Python 3.5?
+------------------------------------------
 
-Here are some of the steps required to accomplish this:
-
-- Source code transformation to rewrite variable annotations to comments
-
-  for example, the code::
-
-        class Point:
-            x: int = 0
-            y: int = 0
-
-   must be rewritten into::
-
-        class Point:
-            x = 0  # type: int
-            y = 0  # type: int
-
-- Source code transformation to rewrite async functions
-
-    for example, the code::
-
-        async def foo():
-            await asyncio.sleep(1.0)
-
-    must be rewritten into::
-
-        @coroutine
-        def foo():
-            yield from asyncio.sleep(1.0)
-
-Will you support Python 2?
---------------------------
-
-There are no plans to support Python 2, but you are welcome to contribute to
-the project (details in the question above is relevant also for Python 2).
+No. Faust requires Python 3.6 or later, since it heavily uses features that were
+introduced in Python 3.6 (`async`, `await`, variable type annotations).
 
 
 I get a maximum number of open files exceeded error by RocksDB when running a Faust app locally. How can I fix this?


### PR DESCRIPTION
This PR updates the statement on Python 2 and 3.5 support in the README and FAQ, changing to the clear and simple statement that Faust requires Python 3.6+.

The previous statement suggested you welcome PRs that de-modernize the codebase and add Python 3.5 and/or Python 2 support.

I'm new to Faust, but my impression is that one of the things that's great about it is that it's modern Python, so IMO this would be a step in the wrong direction. Plus by now the motivation to add Python 2.7 or 3.5 support is very weak, and unlikely to happen anyways?