### PR TITLE
Fix typos in documentation (vs kafka, application, and models pages)

### DIFF
--- a/docs/playbooks/vskafka.rst
+++ b/docs/playbooks/vskafka.rst
@@ -31,7 +31,7 @@ KStream
 
     .. sourcecode:: python
 
-        @app.agent(Topic)
+        @app.agent(topic)
         async def process(stream):
             async for key, event in stream.items():
                 yield myfun(key, event)

--- a/docs/userguide/application.rst
+++ b/docs/userguide/application.rst
@@ -801,7 +801,7 @@ You can also add services at runtime in application subclasses:
 Application Signals
 ===================
 
-You may have experience signals in other frameworks such as `Django`_
+You may have experience with signals in other frameworks such as `Django`_
 and `Celery`_.
 
 The main difference between signals in Faust is that they accept

--- a/docs/userguide/models.rst
+++ b/docs/userguide/models.rst
@@ -660,7 +660,7 @@ is not used.
 Fields with the same name as a reserved keyword
 -----------------------------------------------
 
-Sometimes data you want to describe data will contan
+Sometimes the data you want to describe will contain
 field names that collide with a reserved Python keyword.
 
 One such example is a field named ``in``. You cannot define


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://faust.readthedocs.io/en/master/contributing.html).

## Description

Simply fixing a couple if typos in some documentation pages. There's no created issues that I know of. I simply ran into them while learning about Faust and the OCD in me couldn't help but fix them.