### PR TITLE
Forward http status in table router response

### DIFF
--- a/faust/app/router.py
+++ b/faust/app/router.py
@@ -71,7 +71,7 @@ class Router(RouterT):
         routed_url = request.url.with_host(host).with_port(int(port))
         async with app.http_client.get(routed_url) as response:
             return web.text(
-                await response.text(), content_type=response.content_type)
+                await response.text(), content_type=response.content_type, status=response.status)
 
     def _urlident(self, url: URL) -> Tuple[str, int]:
         return (


### PR DESCRIPTION
## Forward http status in table router response

At the moment the table router does not forward http status.

By this simple fix the status code is correctly forwarded.