### PR TITLE
Fix some cases of hanging rebalance 

### DIFF
--- a/faust/transport/drivers/aiokafka.py
+++ b/faust/transport/drivers/aiokafka.py
@@ -741,6 +741,8 @@ class AIOKafkaConsumerThread(ConsumerThread):
             consumer.seek(tp, offset)
             if offset > 0:
                 self.consumer._read_offset[tp] = offset
+            elif tp in self.consumer._read_offset.keys():
+                del self.consumer._read_offset[tp]
         await asyncio.gather(*[
             consumer.position(tp) for tp in partitions
         ])


### PR DESCRIPTION
## Description
Sometimes during a rebalance, it happens that a partition is assigned to Worker1, then to Worker2 and then again to Worker1. In this case, Worker1 did not finish recovery (last log output is "Resuming...") because the consumer drops the messages from the changelog topic, although the recovery system fetches it.

This commit resets the read_offset if a seek on offset 0 is done.


