### PR TITLE
[web] Move table and router blueprints into debug blueprints

### DIFF
--- a/faust/web/base.py
+++ b/faust/web/base.py
@@ -29,7 +29,6 @@ from faust.types import AppT
 from faust.types.web import BlueprintT, ResourceOptions, View
 
 __all__ = [
-    'DEFAULT_BLUEPRINTS',
     'BlueprintManager',
     'Request',
     'Response',
@@ -41,18 +40,15 @@ _bytes = bytes
 _BPArg = SymbolArg[BlueprintT]
 _BPList = Iterable[Tuple[str, _BPArg]]
 
-DEFAULT_BLUEPRINTS: _BPList = [
-    ('/router', 'faust.web.apps.router:blueprint'),
-    ('/table', 'faust.web.apps.tables.blueprint'),
-]
-
 PRODUCTION_BLUEPRINTS: _BPList = [
     ('', 'faust.web.apps.production_index:blueprint'),
 ]
 
 DEBUG_BLUEPRINTS: _BPList = [
-    ('/graph', 'faust.web.apps.graph:blueprint'),
     ('', 'faust.web.apps.stats:blueprint'),
+    ('/graph', 'faust.web.apps.graph:blueprint'),
+    ('/router', 'faust.web.apps.router:blueprint'),
+    ('/table', 'faust.web.apps.tables.blueprint'),
 ]
 
 CONTENT_SEPARATOR: bytes = b'\r\n\r\n'
@@ -163,7 +159,6 @@ class BlueprintManager:
 class Web(Service):
     """Web server and HTTP interface."""
 
-    default_blueprints: ClassVar[_BPList] = DEFAULT_BLUEPRINTS  # noqa: E704
     production_blueprints: ClassVar[_BPList] = PRODUCTION_BLUEPRINTS
     debug_blueprints: ClassVar[_BPList] = DEBUG_BLUEPRINTS
 
@@ -184,7 +179,7 @@ class Web(Service):
         self.app = app
         self.views = {}
         self.reverse_names = {}
-        blueprints = list(self.default_blueprints)
+        blueprints = []
         if self.app.conf.debug:
             blueprints.extend(self.debug_blueprints)
         else:

--- a/t/unit/web/test_base.py
+++ b/t/unit/web/test_base.py
@@ -3,7 +3,6 @@ from faust.web import Blueprint
 from faust.web.base import (
     BlueprintManager,
     DEBUG_BLUEPRINTS,
-    DEFAULT_BLUEPRINTS,
     PRODUCTION_BLUEPRINTS,
     Web,
 )
@@ -94,13 +93,11 @@ class test_Web:
     @pytest.mark.conf(debug=True)
     def test_debug_blueprints(self, *, web):
         assert web.app.conf.debug
-        assert web.blueprints._enabled == (
-            DEFAULT_BLUEPRINTS + DEBUG_BLUEPRINTS)
+        assert web.blueprints._enabled == DEBUG_BLUEPRINTS
 
     def test_production_blueprints(self, *, web):
         assert not web.app.conf.debug
-        assert web.blueprints._enabled == (
-            DEFAULT_BLUEPRINTS + PRODUCTION_BLUEPRINTS)
+        assert web.blueprints._enabled == PRODUCTION_BLUEPRINTS
 
     def test_url_for(self, *, web):
         web.reverse_names['test'] = '/foo/{bar}/'


### PR DESCRIPTION
## Description

Table and router blueprints should ideally not be exposed in a production app. It may be more appropriate to move these into debug blueprints.