### PR TITLE
Fix sample in "Create a local channel" doc section

### DIFF
--- a/docs/userguide/application.rst
+++ b/docs/userguide/application.rst
@@ -244,7 +244,7 @@ Use :meth:`~@channel` to create an in-memory communication channel:
 
     @app.timer(1.0)
     async def populate():
-        await channel.send(MyModel(303))
+        await channel.send(value=MyModel(303))
 
 .. seealso::
 


### PR DESCRIPTION
`send` doesn't take any positional arguments. The previous example resulted in this error:

```[2020-03-10 15:04:28,062] [2093] [ERROR] [^-App]: Crashed reason=TypeError('send() takes 1 positional argument but 2 were given')
Traceback (most recent call last):
  File "/Users/ath/Development/blah/.venv/lib/python3.7/site-packages/mode/services.py", line 779, in _execute_task
    await task
  File "/Users/ath/Development/blah/.venv/lib/python3.7/site-packages/faust/app/base.py", line 941, in _wrapped
    return await task()
  File "/Users/ath/Development/blah/.venv/lib/python3.7/site-packages/faust/app/base.py", line 991, in around_timer
    await fun(*args)
  File "/Users/ath/Development/blah/kafka/mq.py", line 17, in populate
    await channel.send(MyModel(303))
TypeError: send() takes 1 positional argument but 2 were given```

With the fix applied, it now appears to be working as intended.