### PR TITLE
Fix #549: SetManager.flush timer overlap warning

### DIFF
--- a/faust/tables/objects.py
+++ b/faust/tables/objects.py
@@ -145,7 +145,6 @@ class ChangeloggedObjectManager(Store):
     @Service.task
     async def _periodic_flush(self) -> None:  # pragma: no cover
         async for sleep_time in self.itertimer(2.0, name='SetManager.flush'):
-            await self.sleep(sleep_time)
             self.flush_to_storage()
 
     def reset_state(self) -> None:


### PR DESCRIPTION
I think there is a 2 second sleep inside a 2 second timer, and that's silly, and also causes a timer overlap warning. I removed the sleep
- Fixes #549 
