### PR TITLE
Fix #181: Remove topics with active_partitions from the Conductor when iteration ends

### DIFF
--- a/faust/topics.py
+++ b/faust/topics.py
@@ -477,6 +477,17 @@ class Topic(SerializedChannel, TopicT):
                     retention=self.retention,
                 )
 
+    def on_stop_iteration(self) -> None:
+        """Signal that iteration over this channel was stopped.
+
+        Tip:
+            Remember to call ``super`` when overriding this method.
+        """
+        super().on_stop_iteration()
+        if self.active_partitions is not None:
+            # Remove topics for isolated partitions from the Conductor.
+            self.app.topics.discard(cast(TopicT, self))
+
     def __aiter__(self) -> ChannelT:
         if self.is_iterator:
             return self


### PR DESCRIPTION
## Description

Makes sure to remove topics with active_partitions from the Conductor when iteration stops. This prevents a crash when rebalancing with `isolated_partitions=True` (Fixes #181). Includes test case that captures the current issue, and fails without the fix.
