### PR TITLE
Feature - Add session windowing

### DIFF
--- a/faust/tables/table.py
+++ b/faust/tables/table.py
@@ -46,6 +46,11 @@ class Table(TableT[KT, VT], Collection):
             key_index=key_index,
         )
 
+    def session(self, size: Seconds) -> WindowWrapperT:
+        return self.using_window(
+            windows.SessionWindow(size=size),
+        )
+
     def __missing__(self, key: KT) -> VT:
         if self.default is not None:
             return self.default()

--- a/faust/tables/wrappers.py
+++ b/faust/tables/wrappers.py
@@ -20,6 +20,7 @@ from typing import (
 from mode import Seconds
 from mode.utils.typing import NoReturn
 
+from faust import windows
 from faust.exceptions import ImproperlyConfigured
 from faust.streams import current_event
 from faust.types import EventT, FieldDescriptorT
@@ -218,8 +219,17 @@ class WindowSet(WindowSetT[KT, VT]):
         setting used (:meth:`relative_to_now`, :meth:`relative_to_stream`,
         :meth:`relative_to_field`, etc.)
         """
-        return cast(_Table, self.table)._windowed_timestamp(
-            self.key, self.wrapper.get_timestamp(event or self.event))
+        table = cast(_Table, self.table)
+        event = cast(EventT, event or self.event)
+
+        is_session_window = isinstance(table.window, windows.SessionWindow)
+
+        if is_session_window:
+            return table._windowed_keyed_timestamp(
+                self.key, self.wrapper.get_timestamp(event), event.key)
+        else:
+            return table._windowed_timestamp(
+                self.key, self.wrapper.get_timestamp(event))
 
     def now(self) -> VT:
         """Return current value, using the current system time."""
@@ -422,7 +432,9 @@ class WindowWrapper(WindowWrapperT):
         if not isinstance(value, WindowSetT):
             table = cast(_Table, self.table)
             self.on_set_key(key, value)
-            table._set_windowed(key, value, self.get_timestamp())
+            is_session_window = isinstance(table.window, windows.SessionWindow)
+            event = current_event() if is_session_window else None
+            table._set_windowed(key, value, self.get_timestamp(), event)
 
     def on_set_key(self, key: Any, value: Any) -> None:
         """Call when the value for a key in this table is set."""

--- a/faust/windows.py
+++ b/faust/windows.py
@@ -13,6 +13,7 @@ __all__ = [
     'HoppingWindow',
     'TumblingWindow',
     'SlidingWindow',
+    'SessionWindow',
 ]
 
 NO_CYTHON = bool(os.environ.get('NO_CYTHON', False))
@@ -159,3 +160,29 @@ if not NO_CYTHON:  # pragma: no cover
         Window.register(SlidingWindow)
 else:  # pragma: no cover
     SlidingWindow = _PySlidingWindow
+
+
+class _PySessionWindow(HoppingWindow):
+    """Hopping window type.
+
+    Fixed-size, non-overlapping keyed windows.
+    """
+
+    size: float
+
+    def __init__(self, size: Seconds, expires: Seconds = None) -> None:
+        super(SessionWindow, self).__init__(size, size, expires)
+
+
+if typing.TYPE_CHECKING:
+    SessionWindow = _PySessionWindow
+else:
+    if not NO_CYTHON:  # pragma: no cover
+        try:
+            from ._cython.windows import HoppingWindow
+        except ImportError:
+            SessionWindow = _PySessionWindow
+        else:
+            Window.register(SessionWindow)
+    else:  # pragma: no cover
+        SessionWindow = _PySessionWindow

--- a/t/unit/tables/test_wrappers.py
+++ b/t/unit/tables/test_wrappers.py
@@ -296,7 +296,7 @@ class test_WindowWrapper:
         wtable['foo'] = 300
         wtable.get_timestamp.assert_called_once_with()
         table._set_windowed.assert_called_once_with(
-            'foo', 300, wtable.get_timestamp(),
+            'foo', 300, wtable.get_timestamp(), None,
         )
 
     def test_setitem__key_is_WindowSet(self, *, wtable):

--- a/t/unit/windows/test_session_window.py
+++ b/t/unit/windows/test_session_window.py
@@ -1,0 +1,29 @@
+from faust.windows import SessionWindow
+
+
+class test_SessionWindow:
+
+    def test_session_window_has_just_one_range(self):
+        session = SessionWindow(10)
+        assert len(session.ranges(0)) == 1
+        assert len(session.ranges(5)) == 1
+        assert len(session.ranges(10)) == 1
+
+    def test_end_range_in_session_window_is_within_range(self):
+        session = SessionWindow(10)
+
+        # session windows only have one range
+        base_range = session.ranges(0)[0]
+        base_range_end = base_range[1]
+
+        compare_range = session.ranges(base_range_end)[0]
+
+        assert base_range[0] == compare_range[0]
+        assert base_range[1] == compare_range[1]
+
+    def test_earliest_and_current_range_are_the_same(self):
+        size = 57
+        timestamp = 456
+        window = SessionWindow(size)
+
+        assert window.current(timestamp) == window.earliest(timestamp)


### PR DESCRIPTION
An application I'm working on needs to window data based on event key. It should work as follows:

- the first time a unique event key is seen, open a window of (n) duration
- for each event, get/set values specific to that event key when interfacing with the table
- it should use event time

Here's an example of some code using the `SessionWindow` implementation in this pr

```
log_topic = app.topic('logs', value_type=Log)
table = app.Table('sessions', default=int).session(size=5*60).relative_to_field(Log.timestamp)

@app.agent(log_topic)
async def process_log(logs):
    async for log in logs:
        table['count'] = table['count'].value() + 1
        print(f'city count for {log.client_city}: {table["count"].value()}')

@app.task()
async def look_for_files():
    for line in read_events():
        log = json.loads(line)
        log['timestamp'] = get_epoch(log['timestamp'])
        key = log['session_id']
        await process_log.send(key=key, value=log)

```

input data
```
{ "timestamp": "2020-02-14 15:30:00", "client_city": "new york", "session_id": "1"}
{ "timestamp": "2020-02-14 15:31:00", "client_city": "new york", "session_id": "1"}
{ "timestamp": "2020-02-14 15:32:00", "client_city": "new york", "session_id": "1"}
{ "timestamp": "2020-02-14 15:33:00", "client_city": "new york", "session_id": "1"}
{ "timestamp": "2020-02-14 15:34:00", "client_city": "new york", "session_id": "1"}
{ "timestamp": "2020-02-14 15:35:00", "client_city": "new york", "session_id": "1"}
{ "timestamp": "2020-02-14 15:30:00", "client_city": "miami", "session_id": "2"}
{ "timestamp": "2020-02-14 15:31:00", "client_city": "miami", "session_id": "2"}
{ "timestamp": "2020-02-14 15:32:00", "client_city": "miami", "session_id": "2"}
{ "timestamp": "2020-02-14 15:33:00", "client_city": "miami", "session_id": "2"}
{ "timestamp": "2020-02-14 15:34:00", "client_city": "miami", "session_id": "2"}
{ "timestamp": "2020-02-14 15:35:00", "client_city": "miami", "session_id": "2"}
```

stdout
```
city count for miami: 1
city count for new york: 1
city count for miami: 2
city count for new york: 2
city count for miami: 3
city count for new york: 3
city count for miami: 4
city count for new york: 4
city count for miami: 5
city count for new york: 5
city count for miami: 1
city count for new york: 1
```

As you can see, the events span 6 minutes while the window size is 5 so the values reset after the 5th event.

I'm fairly new to python and faust so I sort of hacked my way through this implementation. There are probably some missing pieces to make this a real feature - I may not be aware of how it could affect other parts of the api. I'm hoping some of ya'll could help guide me in the right direction to get this thing mergeable. Maybe pointing out some tests I should be implementing? Is anything missing regarding error recovery and replaying from the write ahead logs?

`SessionWindow` itself just extends `HoppingWindow` in almost the exact same way that `TumblingWindow` does, so I pretty much just cribbed those tests. 

