### PR TITLE
Fix dropping of messages and/or delay in updating messages

### DIFF
--- a/faust/app/base.py
+++ b/faust/app/base.py
@@ -1317,7 +1317,7 @@ class App(AppT, Service):
         """
         self.client_only = True
         await self.maybe_start()
-        self.consumer.stop_flow()
+        await self.consumer.stop_flow()
         await self.topics.wait_for_subscriptions()
         await self.topics.on_client_only_start()
         self.consumer.resume_flow()
@@ -1487,7 +1487,7 @@ class App(AppT, Service):
             else:
                 if assignment:
                     self.tables.on_partitions_revoked(assignment)
-                    consumer.stop_flow()
+                    await consumer.stop_flow()
                     self.flow_control.suspend()
                     consumer.pause_partitions(assignment)
                     self.flow_control.clear()
@@ -1563,7 +1563,7 @@ class App(AppT, Service):
                 assignment = consumer.assignment()
                 if assignment:
                     on_timeout.info('flow_control.suspend()')
-                    T(consumer.stop_flow)()
+                    await T(consumer.stop_flow)()
                     T(self.flow_control.suspend)()
                     on_timeout.info('consumer.pause_partitions')
                     T(consumer.pause_partitions)(assignment)

--- a/faust/tables/recovery.py
+++ b/faust/tables/recovery.py
@@ -261,6 +261,7 @@ class Recovery(Service):
         self.active_tps.clear()
         self.actives_for_table.clear()
         self.standbys_for_table.clear()
+        self.buffer_sizes.clear()
 
         for tp in assigned_standbys:
             table = self.tables._changelogs.get(tp.topic)

--- a/faust/transport/consumer.py
+++ b/faust/transport/consumer.py
@@ -536,6 +536,7 @@ class Consumer(Service, ConsumerT):
         """Allow consumer to process messages."""
         self.flow_active = True
         self.can_resume_flow.set()
+        self.consumer_waiting.clear()
 
     def pause_partitions(self, tps: Iterable[TP]) -> None:
         """Pause fetching from partitions."""

--- a/faust/types/transports.py
+++ b/faust/types/transports.py
@@ -348,7 +348,7 @@ class ConsumerT(ServiceT):
         ...
 
     @abc.abstractmethod
-    def stop_flow(self) -> None:
+    async def stop_flow(self) -> None:
         ...
 
     @abc.abstractmethod

--- a/t/unit/app/test_base.py
+++ b/t/unit/app/test_base.py
@@ -179,6 +179,7 @@ class test_App:
     async def assert_stop_consumer(self, app):
         consumer = app._consumer = Mock(
             wait_empty=AsyncMock(),
+            stop_flow=AsyncMock(),
         )
         consumer.assignment.return_value = set()
         app.tables = Mock()
@@ -279,6 +280,7 @@ class test_App:
         app.on_partitions_revoked = Mock(send=AsyncMock())
         consumer = app.consumer = Mock(
             wait_empty=AsyncMock(),
+            stop_flow=AsyncMock(),
             transactions=Mock(
                 on_partitions_revoked=AsyncMock(),
             ),
@@ -934,6 +936,7 @@ class test_App:
 
     @pytest.mark.asyncio
     async def test_start_client(self, *, app):
+        app.consumer.stop_flow = AsyncMock()
         app.topics.wait_for_subscriptions = AsyncMock()
         app.maybe_start = AsyncMock(name='app.maybe_start')
         await app.start_client()

--- a/t/unit/transport/test_consumer.py
+++ b/t/unit/transport/test_consumer.py
@@ -603,11 +603,13 @@ class test_Consumer:
         assert consumer._read_offset[TP1] == 401
         consumer._seek.assert_called_once_with(TP1, 401)
 
-    def test_stop_flow(self, *, consumer):
+    @pytest.mark.asyncio
+    async def test_stop_flow(self, *, consumer):
         consumer.flow_active = True
         consumer.can_resume_flow.set()
+        consumer.consumer_waiting.set()
 
-        consumer.stop_flow()
+        await consumer.stop_flow()
 
         assert not consumer.flow_active
         assert not consumer.can_resume_flow.is_set()
@@ -1041,7 +1043,7 @@ class test_ConsumerThread:
         def resume_partitions(self, *args, **kwargs):
             ...
 
-        def stop_flow(self, *args, **kwargs):
+        async def stop_flow(self, *args, **kwargs):
             ...
 
         def resume_flow(self, *args, **kwargs):


### PR DESCRIPTION
## Description

Fixes #580 

There are 2 causes for the bug reported in the above issue. One specific to global tables, another applicable to all tables.

### 1. Specific to global tables:
The leader worker seems to assign all the partitions of topics to itself as 'active' partitions initially, for about 5 to 10 seconds during bootup. After other workers come up, it rebalances and distributes the topics properly, but the buffer_size variable doesn't get cleared, so it ends up retaining the 1000 (recovery_buffer_size) as the buffer size for that topic. This causes issues for global tables wherein the events should get automatically updated across all workers, i.e., the buffer_size should be 1.

### 2. Applicable to all tables:
#### My understanding of fetcher:
The consumer in fetcher writes messages into a queue. All changelog topics related messages then gets put into changelog_queue, which is read by _slurp_changelogs in Recovery. When a rebalance occurs during this, the flow_active will become false, causing the for loop in drain_message to exit. Due to the outer while loop, it restarts, goes into getmany and then to _wait_next_records where the consumer waits until rebalance finishes (i.e., can_resume_flow gets set). Further, the existing data in the queue gets cleared on resume.
#### When the bug occurs:
The consumer in _drain_messages yields every 100 values, and during this yielding, the chances of rebalance occurring and blocking the for loop in _drain_messages is possible. So the consumer gets stuck here, never reaching _wait_next_records. Once rebalance is completed, the loop resumes, and now the consumer has no idea the assignments changed so it proceeds from where it was earlier. This situation is aggravated by the clearing of the queues, which causes skipping of messages in _slurp_changelogs, by as many messages as the value for STREAM_BUFFER_MAXSIZE (default 4096).
#### Possible Fix (implemented in this PR):
Have a flag (event) that gets set when a consumer is waiting, and wait until this flag is set during the stopping of the consumer. This will guarantee the consumer is waiting in _wait_next_records during every rebalance.
