### PR TITLE
making keyword args for topic.send explicit

### DIFF
--- a/docs/userguide/streams.rst
+++ b/docs/userguide/streams.rst
@@ -503,7 +503,7 @@ manually, or use the echo recipe below:
     @app.agent()
     async def process(stream):
         async for value in stream:
-            await other_topic.send(value)
+            await other_topic.send(value=value)
 
 .. _stream-filter:
 


### PR DESCRIPTION
## Description

First off, thanks for the great library! Really enjoying using it so far.

This is a tiny little PR to improve the documentation.

I tried following the documentation in this section for sending data to a topic via `topic.send(...)`, in the echo recipe example here: https://faust.readthedocs.io/en/latest/userguide/streams.html#through-forward-through-another-topic

When I tried this, I got an error: `TypeError: send() takes 1 positional argument but 2 were given`

I found a related issue which has been closed: https://github.com/robinhood/faust/issues/305

For context, the solution was: `The send method method only takes keyword arguments. Try: await destination_topic.send(value=value)`

I was wondering if you agreed it was a good idea to update the example to reflect this?