### PR TITLE
Use chain.from_iterable in app/base.py

### DIFF
--- a/faust/app/base.py
+++ b/faust/app/base.py
@@ -301,7 +301,7 @@ class BootStrategy(BootStrategyT):
         )
 
     def _chain(self, *arguments: Iterable[ServiceT]) -> Iterable[ServiceT]:
-        return cast(Iterable[ServiceT], chain(*arguments))
+        return cast(Iterable[ServiceT], chain.from_iterable(arguments))
 
     def sensors(self) -> Iterable[ServiceT]:
         """Return list of services required to start sensors."""


### PR DESCRIPTION
This is a faster and more idiomatic way of using `itertools.chain`. Instead of computing all the items in the iterable and storing them in memory, they are computed one-by-one and never stored as a huge list. This can save on both runtime and memory space.