### PR TITLE
Use __annotations__ instead of _field_types for Python 3.9 compatibility

### DIFF
--- a/faust/models/typing.py
+++ b/faust/models/typing.py
@@ -405,7 +405,7 @@ class NamedTupleNode(Node):
         fields = ', '.join(
             '{0}={1}'.format(
                 field, self.root.build(var[i], typ))
-            for i, (field, typ) in enumerate(tup._field_types.items())
+            for i, (field, typ) in enumerate(tup.__annotations__.items())
         )
         return f'{self.local_name}({fields})'
 


### PR DESCRIPTION
## Description

Use `__annotations__` instead of _field_types for Python 3.9 compatibility

Fixes #628 