### PR TITLE
Fix committed offset was always less than log-end-offset by 1

### DIFF
--- a/faust/transport/consumer.py
+++ b/faust/transport/consumer.py
@@ -717,7 +717,7 @@ class Consumer(Service, ConsumerT):
             if self.app.topics.acks_enabled_for(message.topic):
                 committed = self._committed_offset[tp]
                 try:
-                    if committed is None or offset > committed:
+                    if committed is None or offset >= committed:
                         acked_index = self._acked_index[tp]
                         if offset not in acked_index:
                             self._unacked_messages.discard(message)
@@ -1003,7 +1003,7 @@ class Consumer(Service, ConsumerT):
             acked[:len(batch) - 1] = []
             self._acked_index[tp].difference_update(batch)
             # return the highest commit offset
-            return batch[-1]
+            return batch[-1] + 1
         return None
 
     async def on_task_error(self, exc: BaseException) -> None:
@@ -1057,7 +1057,7 @@ class Consumer(Service, ConsumerT):
 
                         offset = message.offset
                         r_offset = get_read_offset(tp)
-                        if r_offset is None or offset > r_offset:
+                        if r_offset is None or offset >= r_offset:
                             gap = offset - (r_offset or 0)
                             # We have a gap in income messages
                             if gap > 1 and r_offset:

--- a/t/unit/transport/test_consumer.py
+++ b/t/unit/transport/test_consumer.py
@@ -823,7 +823,8 @@ class test_Consumer:
             TP2: 30,
         }
         assert consumer._filter_committable_offsets({TP1, TP2}) == {
-            TP2: 36,
+            TP1: 5,
+            TP2: 37,
         }
 
     @pytest.mark.asyncio
@@ -959,10 +960,10 @@ class test_Consumer:
 
     @pytest.mark.parametrize('tp,acked,expected_offset', [
         (TP1, [], None),
-        (TP1, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 10),
-        (TP1, [1, 2, 3, 4, 5, 6, 7, 8, 10], 8),
-        (TP1, [1, 2, 3, 4, 6, 7, 8, 10], 4),
-        (TP1, [1, 3, 4, 6, 7, 8, 10], 1),
+        (TP1, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 11),
+        (TP1, [1, 2, 3, 4, 5, 6, 7, 8, 10], 9),
+        (TP1, [1, 2, 3, 4, 6, 7, 8, 10], 5),
+        (TP1, [1, 3, 4, 6, 7, 8, 10], 2),
     ])
     def test_new_offset(self, tp, acked, expected_offset, *, consumer):
         consumer._acked[tp] = acked
@@ -970,10 +971,10 @@ class test_Consumer:
 
     @pytest.mark.parametrize('tp,acked,gaps,expected_offset', [
         (TP1, [], [], None),
-        (TP1, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [], 10),
-        (TP1, [1, 2, 3, 4, 5, 6, 7, 8, 10], [9], 10),
-        (TP1, [1, 2, 3, 4, 6, 7, 8, 10], [5], 8),
-        (TP1, [1, 3, 4, 6, 7, 8, 10], [2, 5, 9], 10),
+        (TP1, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [], 11),
+        (TP1, [1, 2, 3, 4, 5, 6, 7, 8, 10], [9], 11),
+        (TP1, [1, 2, 3, 4, 6, 7, 8, 10], [5], 9),
+        (TP1, [1, 3, 4, 6, 7, 8, 10], [2, 5, 9], 11),
     ])
     def test_new_offset_with_gaps(self, tp, acked, gaps,
                                   expected_offset, *, consumer):


### PR DESCRIPTION
## Description

This PR fixes a bug, that committed offset is always less than log-end-offset in Kafka by 1 when all messages were processed. This bug causes 2 problems:
 - after the worker restart, the last message from topic partition was re-send to the consumer. (Was fixed by this check in the `_drain_messages` function: `if committed is None or offset > committed`. )
 - if there was an offset reset in the partition to the latest, consumer lag is equal to 0. The next message that appears in this partition will be ignored by the consumer due to the previous check, in the `_drain_messages` function.

This PR increases any committing offset by 1, so the log-end-offset will be equal to 0 when all messages are read. 

Fixes #620 
