### PR TITLE
Bump version of pytest to use a version compatible with pytest-asyncio.

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -7,7 +7,7 @@ pytest-forked
 pytest-openfiles>=0.2.0
 pytest-picked
 pytest-random-order>=0.5.4
-pytest~=5.2.2
+pytest>=5.4.0
 python-dateutil>=2.8
 pytz>=2018.7
 -r extras/datadog.txt


### PR DESCRIPTION
Resolves #603 . 