### PR TITLE
Fix on_web_request_end status_code detection

### DIFF
--- a/faust/sensors/monitor.py
+++ b/faust/sensors/monitor.py
@@ -612,7 +612,7 @@ class Monitor(Sensor, KeywordReduce):
                            *,
                            view: web.View = None) -> None:
         """Web server finished working on request."""
-        status_code = HTTPStatus(response.status if response else 500)
+        status_code = HTTPStatus(response.status if response is not None else 500)
         time_start = state['time_start']
         time_end = self.time()
         latency_end = time_end - time_start


### PR DESCRIPTION
Now monitor did not write status code correctly. It always write to stats 500 status code. With this fix all status codes detected correctly