### PR TITLE
Change RocksDB to check the assigned topic name 

### DIFF
--- a/faust/stores/rocksdb.py
+++ b/faust/stores/rocksdb.py
@@ -393,7 +393,7 @@ class Store(base.SerializedStore):
 
     def _dbs_for_actives(self) -> Iterator[DB]:
         actives = self.app.assignor.assigned_actives()
-        topic = self.table._changelog_topic_name()
+        topic = self.table.changelog_topic_name
         for partition, db in self._dbs.items():
             tp = TP(topic=topic, partition=partition)
             # for global tables, keys from all

--- a/t/unit/stores/test_rocksdb.py
+++ b/t/unit/stores/test_rocksdb.py
@@ -422,7 +422,7 @@ class test_Store:
         assert list(store._dbs_for_key(b'key')) == [dbs[2]]
 
     def test__dbs_for_actives(self, *, store, table):
-        table._changelog_topic_name.return_value = 'clog'
+        table._changelog_topic_name = 'clog'
         store.app.assignor.assigned_actives = Mock(return_value=[
             TP('clog', 1),
             TP('clog', 2),


### PR DESCRIPTION
## Description

Changes the RocksDB store to check the assigned topic name for a changelog, rather than the auto-generated one. If the changelog uses a manually-created topic, using the auto-generated name causes `keys()`, `values()`, `items()` on the `Table` object that this store backs to return no data, since the changelog names never match. 

Resolves #654 