### PR TITLE
Update Venusian

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -6,7 +6,7 @@ colorclass>=2.2,<3.0
 mode>=4.4.0,<4.5
 opentracing>=1.3.0,<2.0.0
 terminaltables>=3.1,<4.0
-venusian>=1.1,<2.0
+venusian>=3.0.0,<4.0
 yarl>=1.0,<2.0
 croniter>=0.3.16
 mypy_extensions


### PR DESCRIPTION
I am updating venusian as at the current version it always displays this deprecation warning:

> the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses

but I checked and from version 2.0.0 onwards they fixed this (see https://github.com/Pylons/venusian/blob/24d1d2515972dd61ba1881fec780d658c254a612/CHANGES.rst). 

I'm not familiar with the codebase so there of course could be some breakage with updating the library but in case there's not it would be great to be able to remove that deprecation warning from faust