### PR TITLE
Fix mypy error for field_for_type function. Fixes #672

### DIFF
--- a/faust/models/fields.py
+++ b/faust/models/fields.py
@@ -7,6 +7,7 @@ from operator import attrgetter
 from typing import (
     Any,
     Callable,
+    Hashable,
     Iterable,
     Mapping,
     Optional,
@@ -544,7 +545,10 @@ TYPE_TO_FIELD = {
 
 @lru_cache(maxsize=2048)
 def field_for_type(
-        typ: Type) -> Tuple[Type[FieldDescriptorT], Optional[Type[Tag]]]:
+        htyp: Hashable) -> Tuple[Type[FieldDescriptorT], Optional[Type[Tag]]]:
+    # This is a way to make mypy >= 0.790 happy, as lru_cache
+    # expects a Hashable
+    typ = cast(Type, htyp)
     try:
         # 1) Check if type is in fast index.
         return TYPE_TO_FIELD[typ], None
@@ -557,7 +561,8 @@ def field_for_type(
         else:
             try:
                 if origin is not None and issubclass(origin, Tag):
-                    return field_for_type(typ.__args__[0])[0], typ
+                    return field_for_type(
+                        cast(Hashable, typ.__args__[0]))[0], typ
             except TypeError:
                 pass
 

--- a/faust/models/record.py
+++ b/faust/models/record.py
@@ -7,6 +7,7 @@ from typing import (
     Callable,
     Dict,
     FrozenSet,
+    Hashable,
     List,
     Mapping,
     MutableMapping,
@@ -253,7 +254,9 @@ class Record(Model, abstract=True):  # type: ignore
             else:
                 target_type = typ
             if descr is None or not isinstance(descr, FieldDescriptorT):
-                DescriptorType, tag = field_for_type(target_type)
+                # Make mypy happy
+                hashed_target_type = cast(Hashable, target_type)
+                DescriptorType, tag = field_for_type(hashed_target_type)
                 if tag:
                     add_to_tagged_indices(field, tag)
                 descr = DescriptorType(


### PR DESCRIPTION
## Description

An attempt to fix #672. I'm not all that experienced in using mypy/typing in Python, so there may be better ways. 

`#type: ignore is also an option`, I guess. 