### PR TITLE
fixes #681

### DIFF
--- a/faust/transport/consumer.py
+++ b/faust/transport/consumer.py
@@ -1003,6 +1003,9 @@ class Consumer(Service, ConsumerT):
             batch = next(consecutive_numbers(acked))
             # remove them from the list to clean up.
             acked[:len(batch) - 1] = []
+            latest_commit_id = self._committed_offset.get(tp, -1)
+            if acked and latest_commit_id and acked[0] <= latest_commit_id:
+                acked[:1] = []
             self._acked_index[tp].difference_update(batch)
             # return the highest commit offset
             return batch[-1]


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://faust.readthedocs.io/en/master/contributing.html).

## Description

fixes #681
by remove ack_id that has been committed in _new_offset()

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
