### PR TITLE
[docs] add missing async def to sensors/monitors section

### DIFF
--- a/docs/userguide/sensors.rst
+++ b/docs/userguide/sensors.rst
@@ -67,7 +67,7 @@ in ``app.monitor``:
 .. sourcecode:: python
 
     @app.agent(app.topic('topic'))
-    def mytask(events):
+    async def mytask(events):
         async for event in events:
             # emit how many events are being processed every second.
             print(app.monitor.events_s)


### PR DESCRIPTION
## Description

sample code won't work without async def. I spotted this when reading docs here: https://faust.readthedocs.io/en/latest/userguide/sensors.html#monitor