### PR TITLE
fix skipped event doesn't ack

### DIFF
--- a/faust/streams.py
+++ b/faust/streams.py
@@ -905,10 +905,10 @@ class Stream(StreamT[T_co], Service):
                     except Skip:
                         value = skipped_value
 
-                if value is skipped_value:
-                    continue
-                self.events_total += 1
                 try:
+                    if value is skipped_value:
+                        continue
+                    self.events_total += 1
                     yield value
                 finally:
                     self.current_event = None


### PR DESCRIPTION

## Description

This is a issue that first created as #391 and fixed by #412, and it
seems the commit 5731acdc6b0ceee9e06da32f5c3394e659cb080c had toke
the issue back.
