### PR TITLE
docs: Fix a few typos

### DIFF
--- a/examples/django/proj/settings.py
+++ b/examples/django/proj/settings.py
@@ -93,7 +93,7 @@ DATABASES = {
 
 AUTH_PASSWORD_VALIDATORS = [
     {
-        'NAME': (  # ridiculuously long names are silly
+        'NAME': (  # ridiculously long names are silly
             'django.contrib.auth.password_validation.'
             'UserAttributeSimilarityValidator'),
     },

--- a/faust/transport/drivers/aiokafka.py
+++ b/faust/transport/drivers/aiokafka.py
@@ -802,7 +802,7 @@ class AIOKafkaConsumerThread(ConsumerThread):
         """Fetch batch of messages from server."""
         # Implementation for the Fetcher service.
         _consumer = self._ensure_consumer()
-        # NOTE: Since we are enqueing the fetch request,
+        # NOTE: Since we are enqueuing the fetch request,
         # we need to check when dequeued that we are not in a rebalancing
         # state at that point to return early, or we
         # will create a deadlock (fetch request starts after flow stopped)

--- a/faust/types/settings/params.py
+++ b/faust/types/settings/params.py
@@ -130,7 +130,7 @@ OnDefaultCallable = Callable[[_Settings], IT]
 
 
 class Param(Generic[IT, OT], property):
-    """Faust setting desscription.
+    """Faust setting description.
 
     Describes a Faust setting, how to read it from environment
     variables or from a configuration object.

--- a/faust/types/settings/settings.py
+++ b/faust/types/settings/settings.py
@@ -480,7 +480,7 @@ class Settings(base.SettingsRegistry):
     def env_prefix(self) -> str:
         """Environment variable prefix.
 
-        When configuring Faust by environent variables,
+        When configuring Faust by environment variables,
         this adds a common prefix to all Faust environment value names.
         """
 


### PR DESCRIPTION
There are small typos in:
- examples/django/proj/settings.py
- faust/transport/drivers/aiokafka.py
- faust/types/settings/params.py
- faust/types/settings/settings.py

Fixes:
- Should read `ridiculously` rather than `ridiculuously`.
- Should read `environment` rather than `environent`.
- Should read `enqueuing` rather than `enqueing`.
- Should read `description` rather than `desscription`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md