### PR TITLE
chore: Closes https://github.com/robinhood/faust/issues/757

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,7 +1,7 @@
 aiohttp>=3.5.2,<4.0
 aiohttp_cors>=0.7,<2.0
 robinhood-aiokafka>=1.1.6,<1.2
-click>=6.7,<8.0
+click>=6.7,<9.0
 colorclass>=2.2,<3.0
 mode>=4.4.0,<4.5
 opentracing>=1.3.0,<2.0.0


### PR DESCRIPTION
## Description

Closes https://github.com/robinhood/faust/issues/757

I'd like to use this package in conjunction with other tools such as `black` that depend on a more modern version of the `click` library. As a shot in the dark, I am assuming that the upper bound pin on `click` was conservatively created before that version was released? This seems to be the case given this history of this [line](https://github.com/robinhood/faust/commit/b50f8bf366475286042020f8d05b211584dc94ca) and the release of [click 8.0.0](https://click.palletsprojects.com/en/8.1.x/changes/#version-8-0-0) being two years later.

In the spirit of that, I bumped to the next (yet to be released) major semver and ran the test suite on a local build using `Python 3.7.14` and `click==8.1.3`, and received the following results:

```
Results (28.03s):
    2022 passed
       6 skipped
```

Full disclosure, I did not vet this codebase heavily to see if there are any concerns with this major version bump, but in my own private projects that are pretty vanilla usage of `click` I have been able to make the upgrade pretty transparently. I am mostly relying on the test suite you have here to capture any breakages. I did a very quick scan of the release notes of click 8.0 and it mostly seems like they are making the switch due to dropping python 2 and 3.5 support. I will note that they do not say anything special in their upgrade document for version 8.0 or beyond: https://click.palletsprojects.com/en/8.1.x/upgrading/ which is likely a good sign. Someone with more intimate knowledge of this codebase may want to take a closer look at the extensive release notes just in case: https://click.palletsprojects.com/en/8.1.x/changes/#version-8-0-0
